### PR TITLE
Chat impl refactor

### DIFF
--- a/lib/app/features/chat/data/chat_interface.dart
+++ b/lib/app/features/chat/data/chat_interface.dart
@@ -1,6 +1,7 @@
 import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
 import 'package:min_chat/app/features/chat/data/model/conversation.dart';
 import 'package:min_chat/app/features/chat/data/model/group_conversation.dart';
+import 'package:min_chat/app/features/chat/data/model/group_message.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 
 abstract class IChat {
@@ -12,6 +13,19 @@ abstract class IChat {
 
   /// Send a text message
   Future<void> sendMessage({required Message message});
+
+  /// Send a group text message
+  Future<void> sendGroupMessage({
+    required GroupMessage message,
+    required String id,
+  });
+  
+  /// Send a group voice message
+  Future<void> sendGroupVoiceMessage({
+    required GroupMessage message,
+    required String filePath,
+    required String id,
+  });
 
   /// Send a voice message
   Future<void> sendVoiceMessage({
@@ -25,10 +39,15 @@ abstract class IChat {
     required String senderId,
   });
 
+  /// A Stream of messages for a particular [Conversation]
+  Stream<List<GroupMessage>> groupMessageStream({
+    required String id,
+  });
+
   /// A Stream of this user [Conversation]s
   Stream<List<Conversation>> conversationStream({required String userId});
 
-   /// A Stream of this user [GroupConversation]s
+  /// A Stream of this user [GroupConversation]s
   Stream<List<GroupConversation>> groupConversationStream({
     required String userId,
   });

--- a/lib/app/features/chat/data/chat_interface.dart
+++ b/lib/app/features/chat/data/chat_interface.dart
@@ -26,4 +26,7 @@ abstract class IChat {
 
   /// A Stream of this user [Conversation]s
   Stream<List<Conversation>> conversationStream({required String userId});
+
+  /// Get the list of all users that the [currentUser] converses with
+  Future<List<MinChatUser>> getConversers({required String userId});
 }

--- a/lib/app/features/chat/data/chat_interface.dart
+++ b/lib/app/features/chat/data/chat_interface.dart
@@ -28,6 +28,11 @@ abstract class IChat {
   /// A Stream of this user [Conversation]s
   Stream<List<Conversation>> conversationStream({required String userId});
 
+   /// A Stream of this user [GroupConversation]s
+  Stream<List<GroupConversation>> groupConversationStream({
+    required String userId,
+  });
+
   /// Get the list of all users that the current [MinChatUser] converses with
   Future<List<MinChatUser>> getConversers({required String userId});
 

--- a/lib/app/features/chat/data/chat_interface.dart
+++ b/lib/app/features/chat/data/chat_interface.dart
@@ -6,13 +6,13 @@ import 'package:min_chat/app/features/chat/data/model/message.dart';
 
 abstract class IChat {
   /// Start chat with this [recipientMIdOrEmail]
-  Future<MinChatUser> startConversation({
+  Future<Conversation> startConversation({
     required String recipientMIdOrEmail,
     required MinChatUser currentUser,
   });
 
   /// Send a text message
-  Future<void> sendMessage({required Message message});
+  Future<void> sendMessage({required Message message, required String id});
 
   /// Send a group text message
   Future<void> sendGroupMessage({
@@ -31,12 +31,12 @@ abstract class IChat {
   Future<void> sendVoiceMessage({
     required Message message,
     required String filePath,
+     required String id,
   });
 
   /// A Stream of messages for a particular [Conversation]
   Stream<List<Message>> messageStream({
-    required String recipientId,
-    required String senderId,
+    required String id,
   });
 
   /// A Stream of messages for a particular [Conversation]
@@ -56,7 +56,7 @@ abstract class IChat {
   Future<List<MinChatUser>> getConversers({required String userId});
 
   /// Start a group conversation
-  Future<void> startAGroupConversation({
+  Future<GroupConversation> startAGroupConversation({
     required GroupConversation conversation,
   });
 }

--- a/lib/app/features/chat/data/chat_interface.dart
+++ b/lib/app/features/chat/data/chat_interface.dart
@@ -1,5 +1,6 @@
 import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
 import 'package:min_chat/app/features/chat/data/model/conversation.dart';
+import 'package:min_chat/app/features/chat/data/model/group_conversation.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 
 abstract class IChat {
@@ -27,6 +28,11 @@ abstract class IChat {
   /// A Stream of this user [Conversation]s
   Stream<List<Conversation>> conversationStream({required String userId});
 
-  /// Get the list of all users that the [currentUser] converses with
+  /// Get the list of all users that the current [MinChatUser] converses with
   Future<List<MinChatUser>> getConversers({required String userId});
+
+  /// Start a group conversation
+  Future<void> startAGroupConversation({
+    required GroupConversation conversation,
+  });
 }

--- a/lib/app/features/chat/data/chat_repository.dart
+++ b/lib/app/features/chat/data/chat_repository.dart
@@ -3,6 +3,7 @@ import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
 import 'package:min_chat/app/features/auth/data/user_dao.dart';
 import 'package:min_chat/app/features/chat/data/chat_interface.dart';
 import 'package:min_chat/app/features/chat/data/model/conversation.dart';
+import 'package:min_chat/app/features/chat/data/model/group_conversation.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 import 'package:min_chat/core/data/model/result.dart';
 
@@ -77,6 +78,19 @@ class ChatRepository {
   }) async {
     try {
       final response = await _chatInterface.getConversers(userId: userId);
+      return Result.success(response);
+    } catch (e) {
+      return Result.failure(errorMessage: e.toString());
+    }
+  }
+
+  Future<Result<void>> startAGroupConversation({
+    required GroupConversation conversation,
+  }) async {
+    try {
+      final response = await _chatInterface.startAGroupConversation(
+        conversation: conversation,
+      );
       return Result.success(response);
     } catch (e) {
       return Result.failure(errorMessage: e.toString());

--- a/lib/app/features/chat/data/chat_repository.dart
+++ b/lib/app/features/chat/data/chat_repository.dart
@@ -19,9 +19,9 @@ class ChatRepository {
   final IChat _chatInterface;
   final UserDao _userDao;
 
-  Future<Result<MinChatUser>> startConversation({
+  Future<Result<Conversation>> startConversation({
     required String recipientMIdOrEmail,
-    required String senderMId,
+    
   }) async {
     try {
       final response = await _chatInterface.startConversation(
@@ -36,10 +36,12 @@ class ChatRepository {
 
   Future<Result<void>> sendMessage({
     required Message message,
+    required String id,
   }) async {
     try {
       final response = await _chatInterface.sendMessage(
         message: message,
+        id: id,
       );
       return Result.success(response);
     } catch (e) {
@@ -65,11 +67,13 @@ class ChatRepository {
   Future<Result<void>> sendVoiceMessage({
     required Message message,
     required String filePath,
+    required String id,
   }) async {
     try {
       final response = await _chatInterface.sendVoiceMessage(
         message: message,
         filePath: filePath,
+        id: id,
       );
       return Result.success(response);
     } catch (e) {
@@ -95,12 +99,10 @@ class ChatRepository {
   }
 
   Stream<List<Message>> messageStream({
-    required String recipientId,
-    required String senderId,
+    required String id,
   }) =>
       _chatInterface.messageStream(
-        senderId: senderId,
-        recipientId: recipientId,
+        id: id,
       );
 
   Stream<List<GroupMessage>> groupMessageStream({
@@ -129,7 +131,7 @@ class ChatRepository {
     }
   }
 
-  Future<Result<void>> startAGroupConversation({
+  Future<Result<GroupConversation>> startAGroupConversation({
     required GroupConversation conversation,
   }) async {
     try {

--- a/lib/app/features/chat/data/chat_repository.dart
+++ b/lib/app/features/chat/data/chat_repository.dart
@@ -71,4 +71,15 @@ class ChatRepository {
 
   Stream<List<Conversation>> conversationStream({required String userId}) =>
       _chatInterface.conversationStream(userId: userId);
+
+  Future<Result<List<MinChatUser>>> getConversers({
+    required String userId,
+  }) async {
+    try {
+      final response = await _chatInterface.getConversers(userId: userId);
+      return Result.success(response);
+    } catch (e) {
+      return Result.failure(errorMessage: e.toString());
+    }
+  }
 }

--- a/lib/app/features/chat/data/chat_repository.dart
+++ b/lib/app/features/chat/data/chat_repository.dart
@@ -4,6 +4,7 @@ import 'package:min_chat/app/features/auth/data/user_dao.dart';
 import 'package:min_chat/app/features/chat/data/chat_interface.dart';
 import 'package:min_chat/app/features/chat/data/model/conversation.dart';
 import 'package:min_chat/app/features/chat/data/model/group_conversation.dart';
+import 'package:min_chat/app/features/chat/data/model/group_message.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 import 'package:min_chat/core/data/model/result.dart';
 
@@ -46,6 +47,21 @@ class ChatRepository {
     }
   }
 
+  Future<Result<void>> sendGroupMessage({
+    required GroupMessage message,
+    required String id,
+  }) async {
+    try {
+      final response = await _chatInterface.sendGroupMessage(
+        message: message,
+        id: id,
+      );
+      return Result.success(response);
+    } catch (e) {
+      return Result.failure(errorMessage: e.toString());
+    }
+  }
+
   Future<Result<void>> sendVoiceMessage({
     required Message message,
     required String filePath,
@@ -61,6 +77,23 @@ class ChatRepository {
     }
   }
 
+  Future<Result<void>> sendGroupVoiceMessage({
+    required GroupMessage message,
+    required String filePath,
+    required String id,
+  }) async {
+    try {
+      final response = await _chatInterface.sendGroupVoiceMessage(
+        message: message,
+        filePath: filePath,
+        id: id,
+      );
+      return Result.success(response);
+    } catch (e) {
+      return Result.failure(errorMessage: e.toString());
+    }
+  }
+
   Stream<List<Message>> messageStream({
     required String recipientId,
     required String senderId,
@@ -68,6 +101,13 @@ class ChatRepository {
       _chatInterface.messageStream(
         senderId: senderId,
         recipientId: recipientId,
+      );
+
+  Stream<List<GroupMessage>> groupMessageStream({
+    required String id,
+  }) =>
+      _chatInterface.groupMessageStream(
+        id: id,
       );
 
   Stream<List<Conversation>> conversationStream({required String userId}) =>

--- a/lib/app/features/chat/data/chat_repository.dart
+++ b/lib/app/features/chat/data/chat_repository.dart
@@ -73,6 +73,11 @@ class ChatRepository {
   Stream<List<Conversation>> conversationStream({required String userId}) =>
       _chatInterface.conversationStream(userId: userId);
 
+  Stream<List<GroupConversation>> groupConversationStream({
+    required String userId,
+  }) =>
+      _chatInterface.groupConversationStream(userId: userId);
+
   Future<Result<List<MinChatUser>>> getConversers({
     required String userId,
   }) async {

--- a/lib/app/features/chat/data/firebase_chat_impl.dart
+++ b/lib/app/features/chat/data/firebase_chat_impl.dart
@@ -244,7 +244,7 @@ class FirebaseChat implements IChat {
           )
           .toList();
 
-      // users who partook i.e conversers
+      // users who partook in the conversations i.e conversers
       final users = conversations
           .map(
             (conversation) => conversation.participants

--- a/lib/app/features/chat/data/firebase_chat_impl.dart
+++ b/lib/app/features/chat/data/firebase_chat_impl.dart
@@ -6,6 +6,7 @@ import 'package:injectable/injectable.dart';
 import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
 import 'package:min_chat/app/features/chat/data/chat_interface.dart';
 import 'package:min_chat/app/features/chat/data/model/conversation.dart';
+import 'package:min_chat/app/features/chat/data/model/group_conversation.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 import 'package:min_chat/core/utils/participants_x.dart';
 import 'package:min_chat/core/utils/string_x.dart';
@@ -72,7 +73,7 @@ class FirebaseChat implements IChat {
 
         final recipientUser = MinChatUser.fromMap(recipient);
 
-        final conversationAsMap = {
+        final conversationData = {
           'participantsIds': [recipientUser.id, currentUser.id],
           'participants': [recipientUser.toMap(), currentUser.toMap()],
           'initiatedAt': Timestamp.now().millisecondsSinceEpoch,
@@ -81,7 +82,7 @@ class FirebaseChat implements IChat {
           'lastMessage': null,
         };
 
-        await conversationDocument.set(conversationAsMap);
+        await conversationDocument.set(conversationData);
         return MinChatUser.fromMap(recipient);
       } else {
         throw Exception('User not found!');
@@ -254,7 +255,22 @@ class FirebaseChat implements IChat {
 
       return users;
     } catch (e) {
-      print(e);
+      throw Exception(e);
+    }
+  }
+
+  @override
+  Future<void> startAGroupConversation({
+    required GroupConversation conversation,
+  }) async {
+    try {
+      // create a conversation document
+      final groupConversationDoc =
+          _firebaseFirestore.collection('group-conversations').doc();
+
+      // add a conversation
+      await groupConversationDoc.set(conversation.toMap());
+    } catch (e) {
       throw Exception(e);
     }
   }

--- a/lib/app/features/chat/data/firebase_chat_impl.dart
+++ b/lib/app/features/chat/data/firebase_chat_impl.dart
@@ -224,6 +224,24 @@ class FirebaseChat implements IChat {
           );
 
   @override
+  Stream<List<GroupConversation>> groupConversationStream({
+    required String userId,
+  }) =>
+      _firebaseFirestore
+          .collection('group-conversations')
+          .where(
+           'participantsIds',
+            arrayContains: userId,
+          )
+          .orderBy('lastUpdatedAt', descending: true)
+          .snapshots()
+          .map(
+            (querySnapshot) => querySnapshot.docs
+                .map((doc) => GroupConversation.fromMap(doc.data()))
+                .toList(),
+          );
+
+  @override
   Future<List<MinChatUser>> getConversers({required String userId}) async {
     try {
       // get all conversations where current user is part of
@@ -269,7 +287,9 @@ class FirebaseChat implements IChat {
           _firebaseFirestore.collection('group-conversations').doc();
 
       // add a conversation
-      await groupConversationDoc.set(conversation.toMap());
+      await groupConversationDoc.set(
+        conversation.toMap()..addAll({'documentId': groupConversationDoc.id}),
+      );
     } catch (e) {
       throw Exception(e);
     }

--- a/lib/app/features/chat/data/firebase_chat_impl.dart
+++ b/lib/app/features/chat/data/firebase_chat_impl.dart
@@ -24,7 +24,7 @@ class FirebaseChat implements IChat {
   final FirebaseStorage _firebaseStorage;
 
   @override
-  Future<MinChatUser> startConversation({
+  Future<Conversation> startConversation({
     required String recipientMIdOrEmail,
     required MinChatUser currentUser,
   }) async {
@@ -63,28 +63,40 @@ class FirebaseChat implements IChat {
       if (userDocument.docs.isNotEmpty) {
         final recipient = userDocument.docs.first.data();
 
-        /// A unique way of creating a docId we can always point to;
-        /// concatenate both user ids and sort.
-        ///
-        /// Note to self: Is sorting the chars really the best way?
-        final docId = '${recipient['id']}${currentUser.id}'.sortChars();
+        // /// A unique way of creating a docId we can always point to;
+        // /// concatenate both user ids and sort.
+        // ///
+        // /// Note to self: Is sorting the chars really the best way?
+        // final docId = '${recipient['id']}${currentUser.id}'.sortChars();
 
         final conversationDocument =
-            _firebaseFirestore.collection('conversations').doc(docId);
+            _firebaseFirestore.collection('conversations').doc();
+
+        final docId = conversationDocument.id;
 
         final recipientUser = MinChatUser.fromMap(recipient);
 
-        final conversationData = {
-          'participantsIds': [recipientUser.id, currentUser.id],
-          'participants': [recipientUser.toMap(), currentUser.toMap()],
-          'initiatedAt': Timestamp.now().millisecondsSinceEpoch,
-          'initiatedBy': currentUser.id,
-          'lastUpdatedAt': Timestamp.now().millisecondsSinceEpoch,
-          'lastMessage': null,
-        };
+        // final conversationData = {
+        //   'participantsIds': [recipientUser.id, currentUser.id],
+        //   'participants': [recipientUser.toMap(), currentUser.toMap()],
+        //   'initiatedAt': Timestamp.now().millisecondsSinceEpoch,
+        //   'initiatedBy': currentUser.id,
+        //   'lastUpdatedAt': Timestamp.now().millisecondsSinceEpoch,
+        //   'lastMessage': null,
+        //   'documentId': docId,
+        // };
 
-        await conversationDocument.set(conversationData);
-        return MinChatUser.fromMap(recipient);
+        final conversation = Conversation(
+          participants: [recipientUser, currentUser],
+          initiatedBy: currentUser.id,
+          initiatedAt: DateTime.now(),
+          lastUpdatedAt: DateTime.now(),
+          documentId: docId,
+          participantsIds: [recipientUser.id, currentUser.id],
+        );
+
+        await conversationDocument.set(conversation.toMap());
+        return conversation;
       } else {
         throw Exception('User not found!');
       }
@@ -94,10 +106,13 @@ class FirebaseChat implements IChat {
   }
 
   @override
-  Future<void> sendMessage({required Message message}) async {
+  Future<void> sendMessage({
+    required Message message,
+    required String id,
+  }) async {
     try {
       // generate unique docId for the shared conversation
-      final docId = '${message.recipientId}${message.senderId}'.sortChars();
+      final docId = id;
 
       // recipient and sender conversation document
       final conversationDocument =
@@ -139,10 +154,11 @@ class FirebaseChat implements IChat {
   Future<void> sendVoiceMessage({
     required Message message,
     required String filePath,
+    required String id,
   }) async {
     try {
       // generate unique docId for the shared conversation
-      final docId = '${message.recipientId}${message.senderId}'.sortChars();
+      final docId = id;
 
       // recipient and sender conversation document
       final conversationDocument =
@@ -295,12 +311,11 @@ class FirebaseChat implements IChat {
 
   @override
   Stream<List<Message>> messageStream({
-    required String recipientId,
-    required String senderId,
+    required String id,
   }) =>
       _firebaseFirestore
           .collection('conversations')
-          .doc('$recipientId$senderId'.sortChars())
+          .doc(id)
           .collection('messages')
           .orderBy('timestamp')
           .snapshots()
@@ -397,7 +412,7 @@ class FirebaseChat implements IChat {
   }
 
   @override
-  Future<void> startAGroupConversation({
+  Future<GroupConversation> startAGroupConversation({
     required GroupConversation conversation,
   }) async {
     try {
@@ -405,10 +420,16 @@ class FirebaseChat implements IChat {
       final groupConversationDoc =
           _firebaseFirestore.collection('group-conversations').doc();
 
+      final conversationMap = conversation.toMap()
+        ..addAll({'documentId': groupConversationDoc.id});
+
       // add a conversation
       await groupConversationDoc.set(
-        conversation.toMap()..addAll({'documentId': groupConversationDoc.id}),
+        conversationMap,
       );
+
+      // print(conversationMap.toString());
+      return GroupConversation.fromMap(conversationMap);
     } catch (e) {
       throw Exception(e);
     }

--- a/lib/app/features/chat/data/firebase_chat_impl.dart
+++ b/lib/app/features/chat/data/firebase_chat_impl.dart
@@ -63,12 +63,6 @@ class FirebaseChat implements IChat {
       if (userDocument.docs.isNotEmpty) {
         final recipient = userDocument.docs.first.data();
 
-        // /// A unique way of creating a docId we can always point to;
-        // /// concatenate both user ids and sort.
-        // ///
-        // /// Note to self: Is sorting the chars really the best way?
-        // final docId = '${recipient['id']}${currentUser.id}'.sortChars();
-
         final conversationDocument =
             _firebaseFirestore.collection('conversations').doc();
 
@@ -76,15 +70,6 @@ class FirebaseChat implements IChat {
 
         final recipientUser = MinChatUser.fromMap(recipient);
 
-        // final conversationData = {
-        //   'participantsIds': [recipientUser.id, currentUser.id],
-        //   'participants': [recipientUser.toMap(), currentUser.toMap()],
-        //   'initiatedAt': Timestamp.now().millisecondsSinceEpoch,
-        //   'initiatedBy': currentUser.id,
-        //   'lastUpdatedAt': Timestamp.now().millisecondsSinceEpoch,
-        //   'lastMessage': null,
-        //   'documentId': docId,
-        // };
 
         final conversation = Conversation(
           participants: [recipientUser, currentUser],

--- a/lib/app/features/chat/data/model/conversation.dart
+++ b/lib/app/features/chat/data/model/conversation.dart
@@ -83,6 +83,7 @@ class Conversation extends BaseConversation with EquatableMixin {
       'participants': participants.map((user) => user.toMap()).toList(),
       'lastUpdatedAt': lastUpdatedAt.millisecondsSinceEpoch,
       'participantsIds': participantsIds,
+      'documentId': documentId,
       'lastMessage': lastMessage?.toMap(),
     };
     return {...baseMap, ...additionalInfo()};

--- a/lib/app/features/chat/data/model/conversation.dart
+++ b/lib/app/features/chat/data/model/conversation.dart
@@ -2,14 +2,20 @@ import 'package:equatable/equatable.dart';
 import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 
-class Conversation extends Equatable {
-  const Conversation({
+/// classes that 
+abstract class SortableConversation {
+  DateTime get lastUpdatedAt;
+}
+
+class Conversation extends SortableConversation with EquatableMixin {
+  Conversation({
     required this.participants,
     required this.initiatedBy,
     required this.initiatedAt,
     required this.lastUpdatedAt,
-     this.participantsIds,
+    this.participantsIds,
     this.lastMessage,
+    this.documentId,
   });
 
   factory Conversation.fromMap(Map<String, dynamic> data) {
@@ -32,17 +38,19 @@ class Conversation extends Equatable {
       participants: participants,
       lastUpdatedAt:
           DateTime.fromMillisecondsSinceEpoch(data['lastUpdatedAt'] as int),
-      
       lastMessage: message,
+      documentId: data['documentId'] as String?,
     );
   }
 
   final List<MinChatUser> participants;
   final String initiatedBy;
   final DateTime initiatedAt;
+  @override
   final DateTime lastUpdatedAt;
   final List<String>? participantsIds;
   final Message? lastMessage;
+  final String? documentId;
 
   Map<String, dynamic> toMap() {
     return {

--- a/lib/app/features/chat/data/model/conversation.dart
+++ b/lib/app/features/chat/data/model/conversation.dart
@@ -8,12 +8,14 @@ class Conversation extends Equatable {
     required this.initiatedBy,
     required this.initiatedAt,
     required this.lastUpdatedAt,
+     this.participantsIds,
     this.lastMessage,
   });
 
   factory Conversation.fromMap(Map<String, dynamic> data) {
     // final data = doc.data()! as Map<String, dynamic>;
     final participantsData = data['participants'] as List<dynamic>;
+    // final participantsIds = data['participantsIds'] as List<String>;
 
     final participants = participantsData
         .map((e) => MinChatUser.fromMap(e as Map<String, dynamic>))
@@ -30,6 +32,7 @@ class Conversation extends Equatable {
       participants: participants,
       lastUpdatedAt:
           DateTime.fromMillisecondsSinceEpoch(data['lastUpdatedAt'] as int),
+      
       lastMessage: message,
     );
   }
@@ -38,14 +41,16 @@ class Conversation extends Equatable {
   final String initiatedBy;
   final DateTime initiatedAt;
   final DateTime lastUpdatedAt;
+  final List<String>? participantsIds;
   final Message? lastMessage;
 
   Map<String, dynamic> toMap() {
     return {
-      'initiatedAt': initiatedAt,
+      'initiatedAt': initiatedAt.millisecondsSinceEpoch,
       'initiatedBy': initiatedBy,
       'participants': participants.map((user) => user.toMap()).toList(),
-      'lastUpdatedAt': lastUpdatedAt,
+      'lastUpdatedAt': lastUpdatedAt.millisecondsSinceEpoch,
+      'participantsIds': participantsIds,
       'lastMessage': lastMessage?.toMap(),
     };
   }

--- a/lib/app/features/chat/data/model/conversation.dart
+++ b/lib/app/features/chat/data/model/conversation.dart
@@ -1,14 +1,11 @@
 import 'package:equatable/equatable.dart';
 import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
+import 'package:min_chat/app/features/chat/data/model/group_conversation.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 
-/// classes that 
-abstract class SortableConversation {
-  DateTime get lastUpdatedAt;
-}
-
-class Conversation extends SortableConversation with EquatableMixin {
-  Conversation({
+/// classes that
+abstract class BaseConversation {
+  BaseConversation({
     required this.participants,
     required this.initiatedBy,
     required this.initiatedAt,
@@ -16,6 +13,41 @@ class Conversation extends SortableConversation with EquatableMixin {
     this.participantsIds,
     this.lastMessage,
     this.documentId,
+  });
+
+  factory BaseConversation.fromMap(Map<String, dynamic> map) {
+    if (map['groupName'] != null) {
+      return GroupConversation.fromMap(map);
+    }
+    return Conversation.fromMap(map);
+  }
+
+  final List<MinChatUser> participants;
+  final String initiatedBy;
+  final DateTime initiatedAt;
+  final DateTime lastUpdatedAt;
+  final List<String>? participantsIds;
+  final BaseMessage? lastMessage;
+  final String? documentId;
+
+  // Abstract method to be implemented by subclasses
+  Map<String, dynamic> toMap();
+
+  // Method to be overridden by subclasses to include extra information
+  Map<String, dynamic> additionalInfo() {
+    return {};
+  }
+}
+
+class Conversation extends BaseConversation with EquatableMixin {
+  Conversation({
+    required super.participants,
+    required super.initiatedBy,
+    required super.initiatedAt,
+    required super.lastUpdatedAt,
+    super.participantsIds,
+    super.lastMessage,
+    super.documentId,
   });
 
   factory Conversation.fromMap(Map<String, dynamic> data) {
@@ -43,17 +75,9 @@ class Conversation extends SortableConversation with EquatableMixin {
     );
   }
 
-  final List<MinChatUser> participants;
-  final String initiatedBy;
-  final DateTime initiatedAt;
   @override
-  final DateTime lastUpdatedAt;
-  final List<String>? participantsIds;
-  final Message? lastMessage;
-  final String? documentId;
-
   Map<String, dynamic> toMap() {
-    return {
+    final baseMap = {
       'initiatedAt': initiatedAt.millisecondsSinceEpoch,
       'initiatedBy': initiatedBy,
       'participants': participants.map((user) => user.toMap()).toList(),
@@ -61,6 +85,7 @@ class Conversation extends SortableConversation with EquatableMixin {
       'participantsIds': participantsIds,
       'lastMessage': lastMessage?.toMap(),
     };
+    return {...baseMap, ...additionalInfo()};
   }
 
   @override

--- a/lib/app/features/chat/data/model/group_conversation.dart
+++ b/lib/app/features/chat/data/model/group_conversation.dart
@@ -1,0 +1,38 @@
+import 'package:min_chat/app/features/chat/data/model/conversation.dart';
+import 'package:min_chat/app/features/chat/data/model/group_message.dart';
+
+class GroupConversation extends Conversation {
+  const GroupConversation({
+    required super.initiatedBy,
+    required super.initiatedAt,
+    required super.lastUpdatedAt,
+    required super.participantsIds,
+    required this.groupName,
+    super.lastMessage,
+  }) : super(
+          participants: const [],
+        );
+
+  factory GroupConversation.fromMap(Map<String, dynamic> data) =>
+      GroupConversation(
+        initiatedBy: data['initiatedBy'] as String,
+        initiatedAt:
+            DateTime.fromMillisecondsSinceEpoch(data['initiatedAt'] as int),
+        lastUpdatedAt:
+            DateTime.fromMillisecondsSinceEpoch(data['lastUpdatedAt'] as int),
+        participantsIds: data['participantsIds'] as List<String>,
+        groupName: data['groupName'] as String,
+        lastMessage: data['lastMessage'] != null
+            ? GroupMessage.fromMap(data['lastMessage'] as Map<String, dynamic>)
+            : null,
+      );
+
+  final String groupName;
+
+  @override
+  Map<String, dynamic> toMap() {
+    final baseMap = super.toMap();
+    baseMap['groupName'] = groupName;
+    return baseMap;
+  }
+}

--- a/lib/app/features/chat/data/model/group_conversation.dart
+++ b/lib/app/features/chat/data/model/group_conversation.dart
@@ -1,38 +1,59 @@
+import 'package:equatable/equatable.dart';
 import 'package:min_chat/app/features/chat/data/model/conversation.dart';
 import 'package:min_chat/app/features/chat/data/model/group_message.dart';
 
-class GroupConversation extends Conversation {
-  const GroupConversation({
-    required super.initiatedBy,
-    required super.initiatedAt,
-    required super.lastUpdatedAt,
-    required super.participantsIds,
+class GroupConversation extends SortableConversation with EquatableMixin{
+  GroupConversation({
+    required this.initiatedBy,
+    required this.initiatedAt,
+    required this.lastUpdatedAt,
     required this.groupName,
-    super.lastMessage,
-  }) : super(
-          participants: const [],
-        );
+    required this.participantsIds,
+    this.documentId,
+    this.lastMessage,
+  });
 
-  factory GroupConversation.fromMap(Map<String, dynamic> data) =>
-      GroupConversation(
-        initiatedBy: data['initiatedBy'] as String,
-        initiatedAt:
-            DateTime.fromMillisecondsSinceEpoch(data['initiatedAt'] as int),
-        lastUpdatedAt:
-            DateTime.fromMillisecondsSinceEpoch(data['lastUpdatedAt'] as int),
-        participantsIds: data['participantsIds'] as List<String>,
-        groupName: data['groupName'] as String,
-        lastMessage: data['lastMessage'] != null
-            ? GroupMessage.fromMap(data['lastMessage'] as Map<String, dynamic>)
-            : null,
-      );
+  factory GroupConversation.fromMap(Map<String, dynamic> data) {
+    final message = data['lastMessage'] != null
+        ? GroupMessage.fromMap(data['lastMessage'] as Map<String, dynamic>)
+        : null;
 
-  final String groupName;
-
-  @override
-  Map<String, dynamic> toMap() {
-    final baseMap = super.toMap();
-    baseMap['groupName'] = groupName;
-    return baseMap;
+    return GroupConversation(
+      initiatedBy: data['initiatedBy'] as String,
+      initiatedAt:
+          DateTime.fromMillisecondsSinceEpoch(data['initiatedAt'] as int),
+      lastUpdatedAt:
+          DateTime.fromMillisecondsSinceEpoch(data['lastUpdatedAt'] as int),
+      participantsIds:
+          List<String>.from(data['participantsIds'] as List<dynamic>),
+      groupName: data['groupName'] as String,
+      documentId: data['documentId'] as String,
+      lastMessage: message,
+    );
   }
+
+  final String initiatedBy;
+  final DateTime initiatedAt;
+  @override
+  final DateTime lastUpdatedAt;
+  final List<String> participantsIds;
+  final String groupName;
+  final GroupMessage? lastMessage;
+  final String? documentId;
+
+  Map<String, dynamic> toMap() {
+    return {
+      'initiatedBy': initiatedBy,
+      'initiatedAt': initiatedAt.millisecondsSinceEpoch,
+      'lastUpdatedAt': lastUpdatedAt.millisecondsSinceEpoch,
+      'participantsIds': participantsIds,
+      'groupName': groupName,
+      'documentId': documentId,
+      'lastMessage': lastMessage?.toMap(),
+    };
+  }
+  
+  @override
+  // TODO: implement props
+  List<Object?> get props => throw UnimplementedError();
 }

--- a/lib/app/features/chat/data/model/group_conversation.dart
+++ b/lib/app/features/chat/data/model/group_conversation.dart
@@ -1,16 +1,18 @@
 import 'package:equatable/equatable.dart';
+import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
 import 'package:min_chat/app/features/chat/data/model/conversation.dart';
 import 'package:min_chat/app/features/chat/data/model/group_message.dart';
 
-class GroupConversation extends SortableConversation with EquatableMixin{
+class GroupConversation extends BaseConversation with EquatableMixin {
   GroupConversation({
-    required this.initiatedBy,
-    required this.initiatedAt,
-    required this.lastUpdatedAt,
+    required super.initiatedBy,
+    required super.initiatedAt,
+    required super.lastUpdatedAt,
     required this.groupName,
-    required this.participantsIds,
-    this.documentId,
-    this.lastMessage,
+    required super.participantsIds,
+    super.participants = const <MinChatUser>[],
+    super.documentId,
+    super.lastMessage,
   });
 
   factory GroupConversation.fromMap(Map<String, dynamic> data) {
@@ -32,17 +34,11 @@ class GroupConversation extends SortableConversation with EquatableMixin{
     );
   }
 
-  final String initiatedBy;
-  final DateTime initiatedAt;
-  @override
-  final DateTime lastUpdatedAt;
-  final List<String> participantsIds;
   final String groupName;
-  final GroupMessage? lastMessage;
-  final String? documentId;
 
+  @override
   Map<String, dynamic> toMap() {
-    return {
+    final baseMap = {
       'initiatedBy': initiatedBy,
       'initiatedAt': initiatedAt.millisecondsSinceEpoch,
       'lastUpdatedAt': lastUpdatedAt.millisecondsSinceEpoch,
@@ -51,9 +47,17 @@ class GroupConversation extends SortableConversation with EquatableMixin{
       'documentId': documentId,
       'lastMessage': lastMessage?.toMap(),
     };
+    return baseMap;
   }
-  
+
   @override
-  // TODO: implement props
-  List<Object?> get props => throw UnimplementedError();
+  List<Object?> get props => [
+        participantsIds,
+        initiatedAt,
+        initiatedBy,
+        lastUpdatedAt,
+        lastMessage,
+        groupName,
+        documentId,
+      ];
 }

--- a/lib/app/features/chat/data/model/group_message.dart
+++ b/lib/app/features/chat/data/model/group_message.dart
@@ -1,0 +1,35 @@
+import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
+import 'package:min_chat/app/features/chat/data/model/message.dart';
+
+class GroupMessage extends Message {
+  const GroupMessage({
+    required super.message,
+    required super.messageType,
+    required super.recipientId,
+    required super.senderId,
+    required this.senderInfo,
+    super.status,
+    super.timestamp,
+    super.url,
+  });
+
+  factory GroupMessage.fromMap(Map<String, dynamic> doc) => GroupMessage(
+        senderId: doc['senderId'] as String,
+        recipientId: doc['recipientId'] as String,
+        message: doc['message'] as String,
+        timestamp: DateTime.fromMillisecondsSinceEpoch(doc['timestamp'] as int),
+        senderInfo: doc['senderInfo'] as MinChatUser,
+        status: doc['status'] as String?,
+        messageType: doc['messageType'] as String?,
+        url: doc['url'] as String?,
+      );
+   /// sender info    
+  final MinChatUser senderInfo;
+
+  @override
+  Map<String, dynamic> toMap() {
+    final baseMap = super.toMap();
+    baseMap['senderInfo'] = senderInfo;
+    return baseMap;
+  }
+}

--- a/lib/app/features/chat/data/model/group_message.dart
+++ b/lib/app/features/chat/data/model/group_message.dart
@@ -1,35 +1,50 @@
 import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 
-class GroupMessage extends Message {
-  const GroupMessage({
-    required super.message,
-    required super.messageType,
-    required super.recipientId,
+class GroupMessage extends BaseMessage {
+  GroupMessage({
     required super.senderId,
+    required super.recipientId,
+    required super.message,
     required this.senderInfo,
     super.status,
+    super.messageType,
     super.timestamp,
     super.url,
   });
 
-  factory GroupMessage.fromMap(Map<String, dynamic> doc) => GroupMessage(
-        senderId: doc['senderId'] as String,
-        recipientId: doc['recipientId'] as String,
-        message: doc['message'] as String,
-        timestamp: DateTime.fromMillisecondsSinceEpoch(doc['timestamp'] as int),
-        senderInfo: doc['senderInfo'] as MinChatUser,
-        status: doc['status'] as String?,
-        messageType: doc['messageType'] as String?,
-        url: doc['url'] as String?,
-      );
-   /// sender info    
+  factory GroupMessage.fromMap(Map<String, dynamic> doc) {
+    return GroupMessage(
+      senderId: doc['senderId'] as String,
+      recipientId: doc['recipientId'] as String,
+      message: doc['message'] as String,
+      timestamp: DateTime.fromMillisecondsSinceEpoch(doc['timestamp'] as int),
+      senderInfo:
+          MinChatUser.fromMap(doc['senderInfo'] as Map<String, dynamic>),
+      status: doc['status'] as String?,
+      messageType: doc['messageType'] as String?,
+      url: doc['url'] as String?,
+    );
+  }
   final MinChatUser senderInfo;
 
   @override
   Map<String, dynamic> toMap() {
-    final baseMap = super.toMap();
-    baseMap['senderInfo'] = senderInfo;
-    return baseMap;
+    final baseMap = {
+      'senderId': senderId,
+      'recipientId': recipientId,
+      'message': message,
+      'timestamp': timestamp?.millisecondsSinceEpoch,
+      'messageType': messageType,
+      'status': status,
+      'url': url,
+    };
+
+    return {...baseMap, ...additionalInfo()};
+  }
+
+  @override
+  Map<String, dynamic> additionalInfo() {
+    return {'senderInfo': senderInfo.toMap()};
   }
 }

--- a/lib/app/features/chat/data/model/message.dart
+++ b/lib/app/features/chat/data/model/message.dart
@@ -1,23 +1,24 @@
-class Message {
-  const Message({
+import 'package:min_chat/app/features/chat/data/model/group_message.dart';
+
+abstract class BaseMessage {
+  BaseMessage({
     required this.senderId,
     required this.recipientId,
     required this.message,
-    required this.messageType,
     this.status,
+    this.messageType,
     this.timestamp,
     this.url,
   });
 
-  factory Message.fromMap(Map<String, dynamic> doc) => Message(
-        senderId: doc['senderId'] as String,
-        recipientId: doc['recipientId'] as String,
-        message: doc['message'] as String,
-        timestamp: DateTime.fromMillisecondsSinceEpoch(doc['timestamp'] as int),
-        status: doc['status'] as String?,
-        messageType: doc['messageType'] as String?,
-        url: doc['url'] as String?,
-      );
+  factory BaseMessage.fromMap(Map<String, dynamic> doc) {
+    // Create an instance of the subclass if 'senderInfo' is present
+    if (doc['senderInfo'] != null) {
+      return GroupMessage.fromMap(doc);
+    }
+
+    return Message.fromMap(doc);
+  }
 
   final String senderId;
   final String recipientId;
@@ -25,19 +26,56 @@ class Message {
   final String? status;
   final String? messageType;
   final DateTime? timestamp;
-
-  /// only available if message is media e.g audio
   final String? url;
 
-  Map<String, dynamic> toMap() => {
-        'senderId': senderId,
-        'recipientId': recipientId,
-        'message': message,
-        'timestamp': timestamp,
-        'messageType': messageType,
-        'status': status,
-        'url': url,
-      };
+  // Abstract method to be implemented by subclasses
+  Map<String, dynamic> toMap();
+
+  // Method to be overridden by subclasses to include extra information
+  Map<String, dynamic> additionalInfo() {
+    return {};
+  }
+}
+
+class Message extends BaseMessage {
+  Message({
+    required super.senderId,
+    required super.recipientId,
+    required super.message,
+    super.status,
+    super.messageType,
+    super.timestamp,
+    super.url,
+  });
+
+  factory Message.fromMap(Map<String, dynamic> doc) {
+    return Message(
+      senderId: doc['senderId'] as String,
+      recipientId: doc['recipientId'] as String,
+      message: doc['message'] as String,
+      timestamp: doc['timestamp'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(doc['timestamp'] as int)
+          : null,
+      status: doc['status'] as String?,
+      messageType: doc['messageType'] as String?,
+      url: doc['url'] as String?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toMap() {
+    final baseMap = {
+      'senderId': senderId,
+      'recipientId': recipientId,
+      'message': message,
+      'timestamp': timestamp?.millisecondsSinceEpoch,
+      'messageType': messageType,
+      'status': status,
+      'url': url,
+    };
+
+    return {...baseMap, ...additionalInfo()};
+  }
 }
 
 const textMessageFlag = 'Text';
@@ -45,7 +83,7 @@ const audioMessageFlag = 'Audio';
 const sentStatusFlag = 'Sent';
 const pendingStatusFlag = 'Pending';
 
-extension MessageX on Message {
+extension MessageX on BaseMessage {
   bool isMessageFromCurrentUser(String currentUserId) =>
       senderId == currentUserId;
 }

--- a/lib/app/features/chat/data/model/message.dart
+++ b/lib/app/features/chat/data/model/message.dart
@@ -35,6 +35,11 @@ abstract class BaseMessage {
   Map<String, dynamic> additionalInfo() {
     return {};
   }
+
+  @override
+  String toString() {
+    return toMap().toString();
+  }
 }
 
 class Message extends BaseMessage {

--- a/lib/app/features/chat/domain/get_conversations_use_case.dart
+++ b/lib/app/features/chat/domain/get_conversations_use_case.dart
@@ -11,7 +11,7 @@ class GetConversationsUseCase {
 
   final ChatRepository _chatRepository;
 
-  Stream<List<dynamic>> conversationStreams({
+  Stream<List<BaseConversation>> conversationStreams({
     required String userId,
   }) {
     final conversationStream =

--- a/lib/app/features/chat/domain/get_conversations_use_case.dart
+++ b/lib/app/features/chat/domain/get_conversations_use_case.dart
@@ -20,11 +20,11 @@ class GetConversationsUseCase {
         _chatRepository.groupConversationStream(userId: userId);
 
     return Rx.combineLatest2<List<Conversation>, List<GroupConversation>,
-        List<SortableConversation>>(
+        List<BaseConversation>>(
       conversationStream,
       groupConversationStream,
       (conversations, groupConversations) {
-        final combinedList = <SortableConversation>[
+        final combinedList = <BaseConversation>[
           ...conversations,
           ...groupConversations,
         ]..sort((a, b) => b.lastUpdatedAt.compareTo(a.lastUpdatedAt));

--- a/lib/app/features/chat/ui/cubits/chat_cubit.dart
+++ b/lib/app/features/chat/ui/cubits/chat_cubit.dart
@@ -12,11 +12,10 @@ class ChatCubit extends Cubit<ChatState> {
   final ChatRepository _chatRepository;
 
   void initMessageListener({
-    required String recipientId,
-    required String senderId,
+    required String id,
   }) {
     _chatRepository
-        .messageStream(recipientId: recipientId, senderId: senderId)
+        .messageStream(id: id)
         .listen(updateChats)
         .onError(
           (_) => updateError(

--- a/lib/app/features/chat/ui/cubits/chat_cubit.dart
+++ b/lib/app/features/chat/ui/cubits/chat_cubit.dart
@@ -43,7 +43,6 @@ class ChatCubit extends Cubit<ChatState> {
 
   void updateGroupChats(List<GroupMessage> chats) {
     if (!isClosed) {
-      print(chats.runtimeType);
       emit(ChatState(chats: chats));
     }
   }

--- a/lib/app/features/chat/ui/cubits/chat_cubit.dart
+++ b/lib/app/features/chat/ui/cubits/chat_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:min_chat/app/features/chat/data/chat_repository.dart';
+import 'package:min_chat/app/features/chat/data/model/group_message.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 import 'package:min_chat/core/di/di.dart';
 
@@ -19,13 +20,30 @@ class ChatCubit extends Cubit<ChatState> {
         .listen(updateChats)
         .onError(
           (_) => updateError(
-            '''Error: Payload validation failed. Check for issues with data types, missing fields, or incorrect values in your payload.''',
+            '''Error: An error occured on message stream''',
+          ),
+        );
+  }
+
+  void initGroupMessageListener({
+    required String id,
+  }) {
+    _chatRepository.groupMessageStream(id: id).listen(updateGroupChats).onError(
+          (_) => updateError(
+            '''Error: An error occured on message stream''',
           ),
         );
   }
 
   void updateChats(List<Message> chats) {
     if (!isClosed) {
+      emit(ChatState(chats: chats));
+    }
+  }
+
+  void updateGroupChats(List<GroupMessage> chats) {
+    if (!isClosed) {
+      print(chats.runtimeType);
       emit(ChatState(chats: chats));
     }
   }
@@ -46,12 +64,12 @@ class ChatState {
   factory ChatState.empty() => ChatState(chats: []);
   factory ChatState.withError(
     String errorMessage,
-    List<Message> chats,
+    List<BaseMessage> chats,
   ) =>
       ChatState(chats: chats, errorMessage: errorMessage);
 
   bool get hasError => errorMessage != null;
 
-  final List<Message> chats;
+  final List<BaseMessage> chats;
   final String? errorMessage;
 }

--- a/lib/app/features/chat/ui/cubits/messages_cubit.dart
+++ b/lib/app/features/chat/ui/cubits/messages_cubit.dart
@@ -1,18 +1,18 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:min_chat/app/features/chat/data/chat_repository.dart';
-import 'package:min_chat/app/features/chat/data/model/conversation.dart';
+import 'package:min_chat/app/features/chat/domain/get_conversations_use_case.dart';
 import 'package:min_chat/core/di/di.dart';
 
 class MessagesCubit extends Cubit<MessagesState> {
-  MessagesCubit({ChatRepository? chatRepository})
-      : _chatRepository = chatRepository ?? locator<ChatRepository>(),
+  MessagesCubit({GetConversationsUseCase? getConversationsUseCase})
+      : _getConversationsUseCase =
+            getConversationsUseCase ?? locator<GetConversationsUseCase>(),
         super(MessagesState.empty());
 
-  final ChatRepository _chatRepository;
+  final GetConversationsUseCase _getConversationsUseCase;
 
   void initConversationListener({required String userId}) {
-    _chatRepository
-        .conversationStream(userId: userId)
+    _getConversationsUseCase
+        .conversationStreams(userId: userId)
         .listen(updateConversation)
         .onError(
           (_) => updateError(
@@ -21,7 +21,7 @@ class MessagesCubit extends Cubit<MessagesState> {
         );
   }
 
-  void updateConversation(List<Conversation> conversations) {
+  void updateConversation(List<dynamic> conversations) {
     // print(conversations);
     // final currentState = state;
     // final updatedConversations = currentState.conversations
@@ -48,12 +48,12 @@ class MessagesState {
   factory MessagesState.empty() => MessagesState(conversations: []);
   factory MessagesState.withError(
     String errorMessage,
-    List<Conversation> conversations,
+    List<dynamic> conversations,
   ) =>
       MessagesState(conversations: conversations, errorMessage: errorMessage);
 
   bool get hasError => errorMessage != null;
 
-  final List<Conversation> conversations;
+  final List<dynamic> conversations;
   final String? errorMessage;
 }

--- a/lib/app/features/chat/ui/cubits/messages_cubit.dart
+++ b/lib/app/features/chat/ui/cubits/messages_cubit.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:min_chat/app/features/chat/data/model/conversation.dart';
 import 'package:min_chat/app/features/chat/domain/get_conversations_use_case.dart';
 import 'package:min_chat/core/di/di.dart';
 
@@ -21,7 +22,7 @@ class MessagesCubit extends Cubit<MessagesState> {
         );
   }
 
-  void updateConversation(List<dynamic> conversations) {
+  void updateConversation(List<BaseConversation> conversations) {
     // print(conversations);
     // final currentState = state;
     // final updatedConversations = currentState.conversations
@@ -48,12 +49,12 @@ class MessagesState {
   factory MessagesState.empty() => MessagesState(conversations: []);
   factory MessagesState.withError(
     String errorMessage,
-    List<dynamic> conversations,
+    List<BaseConversation> conversations,
   ) =>
       MessagesState(conversations: conversations, errorMessage: errorMessage);
 
   bool get hasError => errorMessage != null;
 
-  final List<dynamic> conversations;
+  final List<BaseConversation> conversations;
   final String? errorMessage;
 }

--- a/lib/app/features/chat/ui/cubits/send_message_cubit.dart
+++ b/lib/app/features/chat/ui/cubits/send_message_cubit.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:min_chat/app/features/chat/data/chat_repository.dart';
+import 'package:min_chat/app/features/chat/data/model/group_message.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 import 'package:min_chat/core/di/di.dart';
 import 'package:min_chat/core/utils/data_response.dart';
@@ -18,6 +19,42 @@ class SendMessageCubit extends Cubit<SendMessageState> {
     emit(const SendMessageState.processing());
     final response = await _chatRepository.sendMessage(
       message: message,
+    );
+
+    if (response.isFailure) {
+      emit(SendMessageState.failed(message: response.errorMessage));
+    } else {
+      emit(const SendMessageState.done());
+    }
+  }
+  
+  Future<void> sendGroupMessage({
+    required GroupMessage message,
+    required String id,
+  }) async {
+    emit(const SendMessageState.processing());
+    final response = await _chatRepository.sendGroupMessage(
+      message: message,
+      id: id,
+    );
+
+    if (response.isFailure) {
+      emit(SendMessageState.failed(message: response.errorMessage));
+    } else {
+      emit(const SendMessageState.done());
+    }
+  }
+
+  Future<void> sendGroupVoiceMessage({
+    required GroupMessage message,
+    required String id,
+    required String filePath,
+  }) async {
+    emit(const SendMessageState.processing());
+    final response = await _chatRepository.sendGroupVoiceMessage(
+      message: message,
+      id: id,
+      filePath: filePath,
     );
 
     if (response.isFailure) {

--- a/lib/app/features/chat/ui/cubits/send_message_cubit.dart
+++ b/lib/app/features/chat/ui/cubits/send_message_cubit.dart
@@ -15,10 +15,12 @@ class SendMessageCubit extends Cubit<SendMessageState> {
 
   Future<void> sendMessage({
     required Message message,
+    required String id,
   }) async {
     emit(const SendMessageState.processing());
     final response = await _chatRepository.sendMessage(
       message: message,
+      id: id,
     );
 
     if (response.isFailure) {
@@ -27,7 +29,7 @@ class SendMessageCubit extends Cubit<SendMessageState> {
       emit(const SendMessageState.done());
     }
   }
-  
+
   Future<void> sendGroupMessage({
     required GroupMessage message,
     required String id,
@@ -67,11 +69,13 @@ class SendMessageCubit extends Cubit<SendMessageState> {
   Future<void> sendVoiceMessage({
     required Message message,
     required String filePath,
+    required String id,
   }) async {
     emit(const SendMessageState.processing());
     final response = await _chatRepository.sendVoiceMessage(
       message: message,
       filePath: filePath,
+      id: id,
     );
 
     if (response.isFailure) {

--- a/lib/app/features/chat/ui/cubits/start_conversation_cubit.dart
+++ b/lib/app/features/chat/ui/cubits/start_conversation_cubit.dart
@@ -1,7 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
 import 'package:min_chat/app/features/chat/data/chat_repository.dart';
+import 'package:min_chat/app/features/chat/data/model/conversation.dart';
 import 'package:min_chat/core/di/di.dart';
 import 'package:min_chat/core/utils/data_response.dart';
 
@@ -14,12 +14,10 @@ class StartConversationCubit extends Cubit<StartConversationState> {
 
   Future<void> startConversation({
     required String recipientMIdOrEmail,
-    required String senderMid,
   }) async {
     emit(const StartConversationState.processing());
     final response = await _chatRepository.startConversation(
       recipientMIdOrEmail: recipientMIdOrEmail,
-      senderMId: senderMid,
     );
 
     if (response.isFailure) {
@@ -36,7 +34,7 @@ class StartConversationState extends Equatable {
   const StartConversationState.processing()
       : this._(status: DataResponseStatus.processing);
 
-  const StartConversationState.done({required MinChatUser response})
+  const StartConversationState.done({required Conversation response})
       : this._(
           status: DataResponseStatus.success,
           response: response,
@@ -52,7 +50,7 @@ class StartConversationState extends Equatable {
   });
 
   final DataResponseStatus status;
-  final MinChatUser? response;
+  final Conversation? response;
   final String? message;
 
   @override

--- a/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_cubit.dart
+++ b/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_cubit.dart
@@ -2,6 +2,7 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
 import 'package:min_chat/app/features/chat/data/chat_repository.dart';
+import 'package:min_chat/app/features/chat/data/model/group_conversation.dart';
 import 'package:min_chat/core/di/di.dart';
 
 part 'start_groupchat_state.dart';
@@ -9,27 +10,42 @@ part 'start_groupchat_state.dart';
 class StartGroupchatCubit extends Cubit<StartGroupchatState> {
   StartGroupchatCubit({ChatRepository? chatRepository})
       : _chatRepository = chatRepository ?? locator<ChatRepository>(),
-        super(StartGroupchatInitial());
+        super(const StartGroupchatInitial([]));
 
   final ChatRepository _chatRepository;
+
+  // List<MinChatUser> _selectedParticipants = [];
+
+  List<MinChatUser> selectedParticipants = [];
+
+  // set selectedParticipants(List<MinChatUser> participants) {
+  //   selectedParticipants = participants;
+  //   print(selectedParticipants);
+  // }
 
   Future<void> fetchConversers({required String userId}) async {
     final response = await _chatRepository.getConversers(userId: userId);
 
     if (response.isFailure) {
-      emit(ErrorState(errorMessage: response.errorMessage));
+      emit(ErrorState(const [], errorMessage: response.errorMessage));
     } else {
-      emit(GotConversersState(conversers: response.data ?? []));
+      emit(GotConversersState(response.data ?? []));
     }
   }
 
-  Future<void> startGroupChat() async {
-    // final response = await _chatRepository.getConversers(userId: userId);
+  Future<void> startGroupChat({
+    required GroupConversation groupConversation,
+  }) async {
+    emit(CreatingGroupChatState(state.conversers));
 
-    // if (response.isFailure) {
-    //   emit(ErrorState(errorMessage: response.errorMessage));
-    // } else {
-    //   emit(GotConversersState(conversers: response.data ?? []));
-    // }
+    final response = await _chatRepository.startAGroupConversation(
+      conversation: groupConversation,
+    );
+
+    if (response.isFailure) {
+      emit(ErrorState(state.conversers, errorMessage: response.errorMessage));
+    } else {
+      emit(GroupChatCreatedState(state.conversers));
+    }
   }
 }

--- a/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_cubit.dart
+++ b/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_cubit.dart
@@ -45,7 +45,13 @@ class StartGroupchatCubit extends Cubit<StartGroupchatState> {
     if (response.isFailure) {
       emit(ErrorState(state.conversers, errorMessage: response.errorMessage));
     } else {
-      emit(GroupChatCreatedState(state.conversers));
+     
+      emit(
+        GroupChatCreatedState(
+          state.conversers,
+          groupConversation: response.data!,
+        ),
+      );
     }
   }
 }

--- a/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_cubit.dart
+++ b/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_cubit.dart
@@ -1,0 +1,35 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
+import 'package:min_chat/app/features/chat/data/chat_repository.dart';
+import 'package:min_chat/core/di/di.dart';
+
+part 'start_groupchat_state.dart';
+
+class StartGroupchatCubit extends Cubit<StartGroupchatState> {
+  StartGroupchatCubit({ChatRepository? chatRepository})
+      : _chatRepository = chatRepository ?? locator<ChatRepository>(),
+        super(StartGroupchatInitial());
+
+  final ChatRepository _chatRepository;
+
+  Future<void> fetchConversers({required String userId}) async {
+    final response = await _chatRepository.getConversers(userId: userId);
+
+    if (response.isFailure) {
+      emit(ErrorState(errorMessage: response.errorMessage));
+    } else {
+      emit(GotConversersState(conversers: response.data ?? []));
+    }
+  }
+
+  Future<void> startGroupChat() async {
+    // final response = await _chatRepository.getConversers(userId: userId);
+
+    // if (response.isFailure) {
+    //   emit(ErrorState(errorMessage: response.errorMessage));
+    // } else {
+    //   emit(GotConversersState(conversers: response.data ?? []));
+    // }
+  }
+}

--- a/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_state.dart
+++ b/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_state.dart
@@ -1,28 +1,32 @@
 part of 'start_groupchat_cubit.dart';
 
 sealed class StartGroupchatState extends Equatable {
-  const StartGroupchatState();
-
-  @override
-  List<Object> get props => [];
-}
-
-final class StartGroupchatInitial extends StartGroupchatState {}
-
-final class GotConversersState extends StartGroupchatState {
-  const GotConversersState({
-    this.conversers = const [],
-  });
+  const StartGroupchatState(this.conversers);
 
   final List<MinChatUser> conversers;
+
+  @override
+  List<Object> get props => [conversers];
 }
 
-final class CreatingGroupChatState extends StartGroupchatState {}
+final class StartGroupchatInitial extends StartGroupchatState {
+  const StartGroupchatInitial(super.conversers);
+}
 
-final class GroupChatCreatedState extends StartGroupchatState {}
+final class GotConversersState extends StartGroupchatState {
+  const GotConversersState(super.conversers);
+}
+
+final class CreatingGroupChatState extends StartGroupchatState {
+  const CreatingGroupChatState(super.conversers);
+}
+
+final class GroupChatCreatedState extends StartGroupchatState {
+  const GroupChatCreatedState(super.conversers);
+}
 
 class ErrorState extends StartGroupchatState {
-  const ErrorState({this.errorMessage});
+  const ErrorState(super.conversers, {this.errorMessage});
 
   final String? errorMessage;
 }

--- a/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_state.dart
+++ b/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_state.dart
@@ -22,7 +22,11 @@ final class CreatingGroupChatState extends StartGroupchatState {
 }
 
 final class GroupChatCreatedState extends StartGroupchatState {
-  const GroupChatCreatedState(super.conversers);
+  const GroupChatCreatedState(
+    super.conversers, {
+    required this.groupConversation,
+  });
+  final GroupConversation groupConversation;
 }
 
 class ErrorState extends StartGroupchatState {

--- a/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_state.dart
+++ b/lib/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_state.dart
@@ -1,0 +1,28 @@
+part of 'start_groupchat_cubit.dart';
+
+sealed class StartGroupchatState extends Equatable {
+  const StartGroupchatState();
+
+  @override
+  List<Object> get props => [];
+}
+
+final class StartGroupchatInitial extends StartGroupchatState {}
+
+final class GotConversersState extends StartGroupchatState {
+  const GotConversersState({
+    this.conversers = const [],
+  });
+
+  final List<MinChatUser> conversers;
+}
+
+final class CreatingGroupChatState extends StartGroupchatState {}
+
+final class GroupChatCreatedState extends StartGroupchatState {}
+
+class ErrorState extends StartGroupchatState {
+  const ErrorState({this.errorMessage});
+
+  final String? errorMessage;
+}

--- a/lib/app/features/chat/ui/view/chat_view_model.dart
+++ b/lib/app/features/chat/ui/view/chat_view_model.dart
@@ -1,19 +1,19 @@
-import 'package:min_chat/app/features/chat/data/chat_repository.dart';
-import 'package:min_chat/app/features/chat/data/model/message.dart';
-import 'package:min_chat/core/di/di.dart';
+// import 'package:min_chat/app/features/chat/data/chat_repository.dart';
+// import 'package:min_chat/app/features/chat/data/model/message.dart';
+// import 'package:min_chat/core/di/di.dart';
 
-class ChatViewModel {
-  ChatViewModel({ChatRepository? chatRepository})
-      : _chatRepository = chatRepository ?? locator<ChatRepository>();
+// class ChatViewModel {
+//   ChatViewModel({ChatRepository? chatRepository})
+//       : _chatRepository = chatRepository ?? locator<ChatRepository>();
 
-  final ChatRepository _chatRepository;
+//   final ChatRepository _chatRepository;
 
-  Stream<List<Message>> messageStream({
-    required String recipientId,
-    required String senderId,
-  }) =>
-      _chatRepository.messageStream(
-        recipientId: recipientId,
-        senderId: senderId,
-      );
-}
+//   Stream<List<Message>> messageStream({
+//     required String recipientId,
+//     required String senderId,
+//   }) =>
+//       _chatRepository.messageStream(
+//         recipientId: recipientId,
+//         senderId: senderId,
+//       );
+// }

--- a/lib/app/features/chat/ui/views/screens/chat_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/chat_screen.dart
@@ -268,7 +268,7 @@ class _ChatsViewState extends State<_ChatsView> with WidgetsBindingObserver {
                     return Padding(
                       padding: const EdgeInsets.only(top: 5),
                       child: RecipientVoiceBubble(
-                        message: chats[index],
+                        message: chats[index] as Message,
                       ),
                     );
                   }
@@ -299,7 +299,7 @@ class _ChatsViewState extends State<_ChatsView> with WidgetsBindingObserver {
         Padding(
           padding: const EdgeInsets.only(top: 5),
           child: RecipientVoiceBubble(
-            message: chats[index],
+            message: chats[index] as Message,
           ),
         ),
       ],

--- a/lib/app/features/chat/ui/views/screens/group_chat_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/group_chat_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -103,8 +102,9 @@ class _GroupChatScreenState extends State<GroupChatScreen> {
         // messageing text box
         BlocProvider<SendMessageCubit>(
           create: (context) => SendMessageCubit(),
+            // for a group chat the recipient id IS NOT needed
           child: TextVoiceBoxToggler(
-            conversationId: _groupConversation.documentId,
+            conversation: _groupConversation,
           ),
         ),
       ],

--- a/lib/app/features/chat/ui/views/screens/group_chat_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/group_chat_screen.dart
@@ -266,8 +266,8 @@ class _GroupChatViewState extends State<_GroupChatView>
                   if (isTextMessage) {
                     return Padding(
                       padding: const EdgeInsets.only(top: 5),
-                      child: RecipientChatBubble(
-                        message: chats[index],
+                      child: GroupRecipientChatBubble(
+                        message: chats[index] as GroupMessage,
                       ),
                     );
                   }
@@ -276,8 +276,8 @@ class _GroupChatViewState extends State<_GroupChatView>
                   else if (isAudioMessage) {
                     return Padding(
                       padding: const EdgeInsets.only(top: 5),
-                      child: RecipientVoiceBubble(
-                        message: chats[index],
+                      child: GroupRecipientVoiceBubble(
+                        message: chats[index] as GroupMessage,
                       ),
                     );
                   }
@@ -296,19 +296,21 @@ class _GroupChatViewState extends State<_GroupChatView>
     List<BaseMessage> chats,
     int index,
   ) {
+    // final chat = chats[index] as GroupMessage;
+    
     return [
       if (isText) ...[
         Padding(
           padding: const EdgeInsets.only(top: 5),
-          child: RecipientChatBubble(
-            message: chats[index],
+          child: GroupRecipientChatBubble(
+            message: chats[index] as GroupMessage,
           ),
         ),
       ] else ...[
         Padding(
           padding: const EdgeInsets.only(top: 5),
-          child: RecipientVoiceBubble(
-            message: chats[index],
+          child: GroupRecipientVoiceBubble(
+            message: chats[index] as GroupMessage,
           ),
         ),
       ],

--- a/lib/app/features/chat/ui/views/screens/messages_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/messages_screen.dart
@@ -259,6 +259,16 @@ class MessagesListItem extends StatelessWidget {
 
       final conversationUser = message?.senderInfo;
 
+      String senderName() {
+        // currrent user sent last message
+        if (hasLastMessage &&
+            groupConversation.lastMessage!.isMessageFromCurrentUser(user.id)) {
+          return 'You';
+        }
+        // recipient sent last message
+        return conversationUser!.name!.firstword;
+      }
+
       return InkWell(
         onTap: () =>
             context.push(GroupChatScreen.name, extra: groupConversation),
@@ -301,8 +311,8 @@ class MessagesListItem extends StatelessWidget {
                     width: context.width * 0.65,
                     child: Text(
                       hasLastMessage
-                          ? '''${conversationUser!.name!.firstword}: ${message!.message}'''
-                          : 'Be the first to start the  conversation',
+                          ? '''${senderName()}: ${message!.message}'''
+                          : 'Be the first to start the conversation',
                       style: const TextStyle(
                         fontSize: 11,
                         fontWeight: FontWeight.w700,

--- a/lib/app/features/chat/ui/views/screens/messages_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/messages_screen.dart
@@ -9,6 +9,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:min_chat/app/features/auth/ui/cubit/authentication_cubit.dart';
 import 'package:min_chat/app/features/chat/data/model/conversation.dart';
 import 'package:min_chat/app/features/chat/data/model/group_conversation.dart';
+import 'package:min_chat/app/features/chat/data/model/group_message.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 import 'package:min_chat/app/features/chat/ui/cubits/messages_cubit.dart';
 import 'package:min_chat/app/features/chat/ui/cubits/start_conversation_cubit.dart';
@@ -178,6 +179,9 @@ class MessagesListItem extends StatelessWidget {
 
       final hasLastMessage = p2pconversation.lastMessage != null;
 
+      final message =
+          hasLastMessage ? p2pconversation.lastMessage! as Message : null;
+
       String senderName() {
         // currrent user sent last message
         if (hasLastMessage &&
@@ -189,7 +193,7 @@ class MessagesListItem extends StatelessWidget {
       }
 
       return InkWell(
-        onTap: () => context.push(Chats.name, extra: conversationUser),
+        onTap: () => context.push(Chats.name, extra: p2pconversation),
         child: Container(
           height: 72,
           width: context.width,
@@ -223,7 +227,7 @@ class MessagesListItem extends StatelessWidget {
                     width: context.width * 0.65,
                     child: Text(
                       hasLastMessage
-                          ? '''${senderName()}: ${p2pconversation.lastMessage!.message}'''
+                          ? '''${senderName()}: ${message?.message}'''
                           : 'Start a conversation',
                       style: const TextStyle(
                         fontSize: 11,
@@ -255,7 +259,9 @@ class MessagesListItem extends StatelessWidget {
 
       final hasLastMessage = groupConversation.lastMessage != null;
 
-      final message = hasLastMessage ? groupConversation.lastMessage : null;
+      final message = hasLastMessage
+          ? groupConversation.lastMessage! as GroupMessage
+          : null;
 
       final conversationUser = message?.senderInfo;
 
@@ -311,7 +317,7 @@ class MessagesListItem extends StatelessWidget {
                     width: context.width * 0.65,
                     child: Text(
                       hasLastMessage
-                          ? '''${senderName()}: ${message!.message}'''
+                          ? '''${senderName()}: ${message?.message}'''
                           : 'Be the first to start the conversation',
                       style: const TextStyle(
                         fontSize: 11,
@@ -373,7 +379,7 @@ class _StartConversationWidgetState extends State<StartConversationWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final user = context.read<AuthenticationCubit>().state.user;
+    // final user = context.read<AuthenticationCubit>().state.user;
 
     late String midOrEmail;
 
@@ -384,7 +390,6 @@ class _StartConversationWidgetState extends State<StartConversationWidget> {
         focusNode.unfocus();
         cubit.startConversation(
           recipientMIdOrEmail: midOrEmail,
-          senderMid: user.mID!,
         );
       }
     }

--- a/lib/app/features/chat/ui/views/screens/messages_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/messages_screen.dart
@@ -163,7 +163,7 @@ class MessagesListItem extends StatelessWidget {
     super.key,
   });
 
-  final dynamic conversation;
+  final BaseConversation conversation;
 
   static const border = BorderSide(width: 0.3, color: Colors.grey);
 
@@ -184,8 +184,7 @@ class MessagesListItem extends StatelessWidget {
 
       String senderName() {
         // currrent user sent last message
-        if (hasLastMessage &&
-            p2pconversation.lastMessage!.isMessageFromCurrentUser(user.id)) {
+        if (hasLastMessage && message!.isMessageFromCurrentUser(user.id)) {
           return 'You';
         }
         // recipient sent last message
@@ -197,10 +196,7 @@ class MessagesListItem extends StatelessWidget {
         child: Container(
           height: 72,
           width: context.width,
-          padding: const EdgeInsets.only(
-            left: 9,
-            right: 8,
-          ),
+          padding: _padding,
           decoration: const BoxDecoration(
             border: Border(top: border, bottom: border),
           ),
@@ -229,13 +225,7 @@ class MessagesListItem extends StatelessWidget {
                       hasLastMessage
                           ? '''${senderName()}: ${message?.message}'''
                           : 'Start a conversation',
-                      style: const TextStyle(
-                        fontSize: 11,
-                        fontWeight: FontWeight.w700,
-                        fontStyle: FontStyle.italic,
-                        color: Colors.black54,
-                        overflow: TextOverflow.ellipsis,
-                      ),
+                      style: _lastMessageTextStyle,
                       maxLines: 1,
                     ),
                   ),
@@ -267,8 +257,7 @@ class MessagesListItem extends StatelessWidget {
 
       String senderName() {
         // currrent user sent last message
-        if (hasLastMessage &&
-            groupConversation.lastMessage!.isMessageFromCurrentUser(user.id)) {
+        if (hasLastMessage && message!.isMessageFromCurrentUser(user.id)) {
           return 'You';
         }
         // recipient sent last message
@@ -281,10 +270,7 @@ class MessagesListItem extends StatelessWidget {
         child: Container(
           height: 72,
           width: context.width,
-          padding: const EdgeInsets.only(
-            left: 9,
-            right: 8,
-          ),
+          padding: _padding,
           decoration: const BoxDecoration(
             border: Border(top: border, bottom: border),
           ),
@@ -319,13 +305,7 @@ class MessagesListItem extends StatelessWidget {
                       hasLastMessage
                           ? '''${senderName()}: ${message?.message}'''
                           : 'Be the first to start the conversation',
-                      style: const TextStyle(
-                        fontSize: 11,
-                        fontWeight: FontWeight.w700,
-                        fontStyle: FontStyle.italic,
-                        color: Colors.black54,
-                        overflow: TextOverflow.ellipsis,
-                      ),
+                      style: _lastMessageTextStyle,
                       maxLines: 1,
                     ),
                   ),
@@ -345,6 +325,23 @@ class MessagesListItem extends StatelessWidget {
         ),
       );
     }
+  }
+
+  TextStyle get _lastMessageTextStyle {
+    return const TextStyle(
+      fontSize: 11,
+      fontWeight: FontWeight.w700,
+      fontStyle: FontStyle.italic,
+      color: Colors.black54,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+
+  EdgeInsets get _padding {
+    return const EdgeInsets.only(
+      left: 9,
+      right: 8,
+    );
   }
 }
 

--- a/lib/app/features/chat/ui/views/screens/messages_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/messages_screen.dart
@@ -12,6 +12,7 @@ import 'package:min_chat/app/features/chat/data/model/message.dart';
 import 'package:min_chat/app/features/chat/ui/cubits/messages_cubit.dart';
 import 'package:min_chat/app/features/chat/ui/cubits/start_conversation_cubit.dart';
 import 'package:min_chat/app/features/chat/ui/views/screens/chat_screen.dart';
+import 'package:min_chat/app/features/chat/ui/views/screens/start_groupchat_screen.dart';
 import 'package:min_chat/app/features/user/ui/user_options_screen.dart';
 import 'package:min_chat/app/shared/ui/app_button.dart';
 import 'package:min_chat/app/shared/ui/app_dialog.dart';
@@ -375,7 +376,7 @@ AppExpandableFab _buildExpandableFab(BuildContext context) {
     children: [
       ActionButton(
         tooltip: 'Start a group chat',
-        onPressed: () {},
+        onPressed: () => context.push(StartGroupchatScreen.name),
         icon: const FaIcon(FontAwesomeIcons.userGroup),
       ),
       ActionButton(

--- a/lib/app/features/chat/ui/views/screens/messages_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/messages_screen.dart
@@ -13,6 +13,7 @@ import 'package:min_chat/app/features/chat/data/model/message.dart';
 import 'package:min_chat/app/features/chat/ui/cubits/messages_cubit.dart';
 import 'package:min_chat/app/features/chat/ui/cubits/start_conversation_cubit.dart';
 import 'package:min_chat/app/features/chat/ui/views/screens/chat_screen.dart';
+import 'package:min_chat/app/features/chat/ui/views/screens/group_chat_screen.dart';
 import 'package:min_chat/app/features/chat/ui/views/screens/start_groupchat_screen.dart';
 import 'package:min_chat/app/features/user/ui/user_options_screen.dart';
 import 'package:min_chat/app/shared/ui/app_button.dart';
@@ -259,7 +260,8 @@ class MessagesListItem extends StatelessWidget {
       final conversationUser = message?.senderInfo;
 
       return InkWell(
-        onTap: () => context.push(Chats.name, extra: conversationUser),
+        onTap: () =>
+            context.push(GroupChatScreen.name, extra: groupConversation),
         child: Container(
           height: 72,
           width: context.width,

--- a/lib/app/features/chat/ui/views/screens/messages_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/messages_screen.dart
@@ -15,6 +15,7 @@ import 'package:min_chat/app/features/chat/ui/views/screens/chat_screen.dart';
 import 'package:min_chat/app/features/user/ui/user_options_screen.dart';
 import 'package:min_chat/app/shared/ui/app_button.dart';
 import 'package:min_chat/app/shared/ui/app_dialog.dart';
+import 'package:min_chat/app/shared/ui/app_expandable_fab.dart';
 import 'package:min_chat/app/shared/ui/app_text_field.dart';
 import 'package:min_chat/core/utils/data_response.dart';
 import 'package:min_chat/core/utils/datetime_x.dart';
@@ -38,11 +39,7 @@ class _MessagesScreenState extends State<MessagesScreen> {
   Widget build(BuildContext context) {
     final user = context.read<AuthenticationCubit>().state.user;
     return Scaffold(
-      floatingActionButton: FloatingActionButton(
-        backgroundColor: Colors.black,
-        child: const FaIcon(FontAwesomeIcons.penToSquare),
-        onPressed: () => _showStartConversationModal(context),
-      ),
+      floatingActionButton: _buildExpandableFab(context),
       body: BlocProvider<MessagesCubit>(
         create: (context) =>
             MessagesCubit()..initConversationListener(userId: user.id),
@@ -191,7 +188,7 @@ class MessagesListItem extends StatelessWidget {
         width: context.width,
         padding: const EdgeInsets.only(
           left: 9,
-          right: 9,
+          right: 8,
         ),
         decoration: const BoxDecoration(
           border: Border(top: border, bottom: border),
@@ -247,13 +244,6 @@ class MessagesListItem extends StatelessWidget {
       ),
     );
   }
-}
-
-void _showStartConversationModal(BuildContext context) {
-  AppDialog.showAppDialog(
-    context,
-    const StartConversationWidget(),
-  );
 }
 
 class StartConversationWidget extends StatefulWidget {
@@ -370,4 +360,29 @@ class _StartConversationWidgetState extends State<StartConversationWidget> {
       ),
     );
   }
+}
+
+void _showStartConversationModal(BuildContext context) {
+  AppDialog.showAppDialog(
+    context,
+    const StartConversationWidget(),
+  );
+}
+
+AppExpandableFab _buildExpandableFab(BuildContext context) {
+  return AppExpandableFab(
+    distance: 70,
+    children: [
+      ActionButton(
+        tooltip: 'Start a group chat',
+        onPressed: () {},
+        icon: const FaIcon(FontAwesomeIcons.userGroup),
+      ),
+      ActionButton(
+        tooltip: 'Start a conversation',
+        onPressed: () => _showStartConversationModal(context),
+        icon: const FaIcon(FontAwesomeIcons.userPen),
+      ),
+    ],
+  );
 }

--- a/lib/app/features/chat/ui/views/screens/start_groupchat_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/start_groupchat_screen.dart
@@ -1,5 +1,11 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
+import 'package:min_chat/app/features/auth/ui/cubit/authentication_cubit.dart';
+import 'package:min_chat/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_cubit.dart';
 import 'package:min_chat/app/shared/ui/app_button.dart';
 
 class StartGroupchatScreen extends StatefulWidget {
@@ -12,102 +18,138 @@ class StartGroupchatScreen extends StatefulWidget {
 }
 
 class _StartGroupchatScreenState extends State<StartGroupchatScreen> {
-  final List<Contact> _contacts = [
-    // Add your contacts here
-    Contact(name: 'Alice'),
-    Contact(name: 'Bob'),
-    Contact(name: 'Charlie'),
-  ];
-
   bool _isCreateGroupButtonEnabled = false;
+  final _selectedUsers = <MinChatUser>[];
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: Colors.white,
-      appBar: AppBar(
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
+    final user = context.read<AuthenticationCubit>().state.user;
+
+    return BlocProvider<StartGroupchatCubit>(
+      create: (context) =>
+          StartGroupchatCubit()..fetchConversers(userId: user.id),
+      child: Scaffold(
         backgroundColor: Colors.white,
-        title: const Text(
-          'Start Group Chat',
-          style: TextStyle(color: Colors.black, fontSize: 20),
+        appBar: AppBar(
+          elevation: 0,
+          iconTheme: const IconThemeData(color: Colors.black),
+          backgroundColor: Colors.white,
+          title: const Text(
+            'Start a group chat',
+            style: TextStyle(color: Colors.black, fontSize: 20),
+          ),
         ),
-      ),
-      body: Column(
-        children: [
-          ListView.separated(
-            itemCount: _contacts.length,
-            shrinkWrap: true,
-            padding: const EdgeInsets.all(8),
-            separatorBuilder: (context, index) => const Gap(8),
-            itemBuilder: (context, index) {
-              final contact = _contacts[index];
-              return CheckboxListTile(
-                activeColor: Colors.black,
-                shape: RoundedRectangleBorder(
-                  side: const BorderSide(width: 0.3, color: Colors.grey),
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                checkboxShape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                // shape: const CircleBorder(side: BorderSide()),
-                title: Text(contact.name),
-                subtitle: const Text('2939933BH'),
-                value: contact.isSelected,
-                onChanged: (selected) {
-                  setState(() {
-                    contact.isSelected = selected!;
-                    _updateCreateGroupButtonState();
-                  });
-                },
+        body: BlocConsumer<StartGroupchatCubit, StartGroupchatState>(
+          listener: (context, state) {
+            if (state is ErrorState) {
+              print(state.errorMessage);
+            }
+          },
+          builder: (context, state) {
+            if (state is StartGroupchatInitial) {
+              return const Center(child: CupertinoActivityIndicator());
+            } else {
+              final users = (state as GotConversersState).conversers;
+
+              if (users.isEmpty) {
+                return const _NoConversers();
+              }
+
+              return Column(
+                children: [
+                  ListView.separated(
+                    itemCount: users.length,
+                    shrinkWrap: true,
+                    padding: const EdgeInsets.all(8),
+                    separatorBuilder: (context, index) => const Gap(8),
+                    itemBuilder: (context, index) {
+                      final user = users[index];
+
+                      return CheckboxListTile(
+                        activeColor: Colors.black,
+                        shape: RoundedRectangleBorder(
+                          side:
+                              const BorderSide(width: 0.3, color: Colors.grey),
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        checkboxShape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        // shape: const CircleBorder(side: BorderSide()),
+                        title: Text(user.name!),
+                        subtitle: Text(user.mID!),
+                        value: _selectedUsers.contains(user),
+                        onChanged: (selected) {
+                          setState(() {
+                            if (selected!) {
+                              _selectedUsers.add(user);
+                            } else {
+                              _selectedUsers.remove(user);
+                            }
+                            _updateCreateGroupButtonState();
+                          });
+                        },
+                      );
+                    },
+                  ),
+                  const Gap(80),
+                  Padding(
+                    padding: const EdgeInsets.only(right: 10),
+                    child: Align(
+                      alignment: Alignment.bottomRight,
+                      child: AppIconButton(
+                        text: 'Start Conversation',
+                        color: Colors.black,
+                        icon: Container(),
+                        height: 40,
+                        // width: 130,
+                        onPressed: _isCreateGroupButtonEnabled
+                            ? () {
+                                // Implement group creation logic using selected contacts
+                              }
+                            : null,
+                      ),
+                    ),
+                  ),
+                ],
               );
-            },
-          ),
-          const Gap(80),
-          Padding(
-            padding: const EdgeInsets.only(right: 10),
-            child: Align(
-              alignment: Alignment.bottomRight,
-              child: AppIconButton(
-                text: 'Start Conversation',
-                color: Colors.black,
-                icon: Container(),
-                height: 40,
-                // width: 130,
-                onPressed: _isCreateGroupButtonEnabled
-                    ? () {
-                        // Implement group creation logic using selected contacts
-                      }
-                    : null,
-              ),
-              // child: ElevatedButton(
-              //   style: ButtonStyle(),
-              //   onPressed: _isCreateGroupButtonEnabled
-              //       ? () {
-              //           // Implement group creation logic using selected contacts
-              //         }
-              //       : null,
-              //   child: const Text('Create Group'),
-              // ),
-            ),
-          ),
-        ],
+            }
+          },
+        ),
       ),
     );
   }
 
   void _updateCreateGroupButtonState() {
     setState(() {
-      _isCreateGroupButtonEnabled =
-          _contacts.any((contact) => contact.isSelected);
+      _isCreateGroupButtonEnabled = _selectedUsers.isNotEmpty;
     });
   }
 }
 
-class Contact {
-  Contact({required this.name, this.isSelected = false});
-  final String name;
-  bool isSelected;
+class _NoConversers extends StatelessWidget {
+  const _NoConversers();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Image.asset(
+          'assets/images/min_mascot.png',
+          width: 60,
+          height: 60,
+        ),
+        Text(
+          '''You have no active conversations yet.\n Click the button below to begin a conversation.''',
+          textAlign: TextAlign.center,
+          style: GoogleFonts.varelaRound(
+            fontSize: 15,
+            fontWeight: FontWeight.bold,
+            color: Colors.grey,
+          ),
+        ),
+      ],
+    );
+  }
 }

--- a/lib/app/features/chat/ui/views/screens/start_groupchat_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/start_groupchat_screen.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+import 'package:min_chat/app/shared/ui/app_button.dart';
+
+class StartGroupchatScreen extends StatefulWidget {
+  const StartGroupchatScreen({super.key});
+
+  static const String name = '/startGroupchat';
+
+  @override
+  State<StartGroupchatScreen> createState() => _StartGroupchatScreenState();
+}
+
+class _StartGroupchatScreenState extends State<StartGroupchatScreen> {
+  final List<Contact> _contacts = [
+    // Add your contacts here
+    Contact(name: 'Alice'),
+    Contact(name: 'Bob'),
+    Contact(name: 'Charlie'),
+  ];
+
+  bool _isCreateGroupButtonEnabled = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        elevation: 0,
+        iconTheme: const IconThemeData(color: Colors.black),
+        backgroundColor: Colors.white,
+        title: const Text(
+          'Start Group Chat',
+          style: TextStyle(color: Colors.black, fontSize: 20),
+        ),
+      ),
+      body: Column(
+        children: [
+          ListView.separated(
+            itemCount: _contacts.length,
+            shrinkWrap: true,
+            padding: const EdgeInsets.all(8),
+            separatorBuilder: (context, index) => const Gap(8),
+            itemBuilder: (context, index) {
+              final contact = _contacts[index];
+              return CheckboxListTile(
+                activeColor: Colors.black,
+                shape: RoundedRectangleBorder(
+                  side: const BorderSide(width: 0.3, color: Colors.grey),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                checkboxShape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                // shape: const CircleBorder(side: BorderSide()),
+                title: Text(contact.name),
+                subtitle: const Text('2939933BH'),
+                value: contact.isSelected,
+                onChanged: (selected) {
+                  setState(() {
+                    contact.isSelected = selected!;
+                    _updateCreateGroupButtonState();
+                  });
+                },
+              );
+            },
+          ),
+          const Gap(80),
+          Padding(
+            padding: const EdgeInsets.only(right: 10),
+            child: Align(
+              alignment: Alignment.bottomRight,
+              child: AppIconButton(
+                text: 'Start Conversation',
+                color: Colors.black,
+                icon: Container(),
+                height: 40,
+                // width: 130,
+                onPressed: _isCreateGroupButtonEnabled
+                    ? () {
+                        // Implement group creation logic using selected contacts
+                      }
+                    : null,
+              ),
+              // child: ElevatedButton(
+              //   style: ButtonStyle(),
+              //   onPressed: _isCreateGroupButtonEnabled
+              //       ? () {
+              //           // Implement group creation logic using selected contacts
+              //         }
+              //       : null,
+              //   child: const Text('Create Group'),
+              // ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _updateCreateGroupButtonState() {
+    setState(() {
+      _isCreateGroupButtonEnabled =
+          _contacts.any((contact) => contact.isSelected);
+    });
+  }
+}
+
+class Contact {
+  Contact({required this.name, this.isSelected = false});
+  final String name;
+  bool isSelected;
+}

--- a/lib/app/features/chat/ui/views/screens/start_groupchat_screen.dart
+++ b/lib/app/features/chat/ui/views/screens/start_groupchat_screen.dart
@@ -2,10 +2,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:min_chat/app/features/auth/ui/cubit/authentication_cubit.dart';
 import 'package:min_chat/app/features/chat/data/model/group_conversation.dart';
 import 'package:min_chat/app/features/chat/ui/cubits/start_groupchat_cubit/start_groupchat_cubit.dart';
+import 'package:min_chat/app/features/chat/ui/views/screens/group_chat_screen.dart';
 import 'package:min_chat/app/shared/ui/app_button.dart';
 import 'package:min_chat/app/shared/ui/app_dialog.dart';
 import 'package:min_chat/app/shared/ui/app_text_field.dart';
@@ -47,7 +49,7 @@ class _StartGroupchatScreenState extends State<StartGroupchatScreen> {
           listener: (context, state) {
             if (state is ErrorState) {
               // error message display
-            } 
+            }
           },
           builder: (context, state) {
             final selectedUsers =
@@ -247,9 +249,12 @@ class _EnterGroupNameWidgetState extends State<EnterGroupNameWidget> {
                 BlocConsumer<StartGroupchatCubit, StartGroupchatState>(
                   listener: (context, state) {
                     if (state is GroupChatCreatedState) {
-                      // context
-                      //   ..pop() // remove dialog
-                      //   ..push('');
+                      context
+                        ..pop() // pop dialog
+                        ..pushReplacement(
+                          GroupChatScreen.name,
+                          extra: state.groupConversation,
+                        );
                     } else if (state is ErrorState) {
                       toastification.show(
                         context: context,

--- a/lib/app/features/chat/ui/views/widgets/message_text_box.dart
+++ b/lib/app/features/chat/ui/views/widgets/message_text_box.dart
@@ -6,6 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:gap/gap.dart';
 import 'package:min_chat/app/features/auth/ui/cubit/authentication_cubit.dart';
+import 'package:min_chat/app/features/chat/data/model/conversation.dart';
 import 'package:min_chat/app/features/chat/data/model/group_message.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 import 'package:min_chat/app/features/chat/ui/cubits/send_message_cubit.dart';
@@ -15,10 +16,16 @@ import 'package:min_chat/app/features/chat/ui/views/widgets/voice_recorder_box.d
 import 'package:min_chat/core/utils/sized_context.dart';
 
 class TextVoiceBoxToggler extends StatefulWidget {
-  const TextVoiceBoxToggler({this.recipientId, this.conversationId, super.key});
+  const TextVoiceBoxToggler({
+    required this.conversation,
+    this.recipientId,
+    super.key,
+  });
 
+  final BaseConversation conversation;
+  /// A null [recipientId] typically means this is a group conversation
+  /// and should be treated as such
   final String? recipientId;
-  final String? conversationId;
 
   @override
   State<TextVoiceBoxToggler> createState() => _TextVoiceBoxTogglerState();
@@ -26,6 +33,13 @@ class TextVoiceBoxToggler extends StatefulWidget {
 
 class _TextVoiceBoxTogglerState extends State<TextVoiceBoxToggler> {
   final AudioPlayer _audioPlayer = AudioPlayer();
+  late BaseConversation conversation;
+
+  @override
+  void initState() {
+    conversation = widget.conversation;
+    super.initState();
+  }
 
   @override
   void dispose() {
@@ -59,13 +73,13 @@ class _TextVoiceBoxTogglerState extends State<TextVoiceBoxToggler> {
             child: isShowingTextBox
                 ? MessagingTextBox(
                     recipientId: widget.recipientId,
-                    conversationId: widget.conversationId,
+                    conversationId: conversation.documentId!,
                   )
                 : Align(
                     alignment: Alignment.bottomCenter,
                     child: VoiceRecorderBox(
                       recipientId: widget.recipientId,
-                      conversationId: widget.conversationId,
+                      conversationId: conversation.documentId,
                       audioPlayer: _audioPlayer,
                     ),
                   ),
@@ -89,10 +103,14 @@ class _TextVoiceBoxTogglerState extends State<TextVoiceBoxToggler> {
 }
 
 class MessagingTextBox extends StatefulWidget {
-  const MessagingTextBox({this.recipientId, this.conversationId, super.key});
+  const MessagingTextBox({
+    required this.conversationId,
+    this.recipientId,
+    super.key,
+  });
 
   final String? recipientId;
-  final String? conversationId;
+  final String conversationId;
 
   @override
   State<MessagingTextBox> createState() => _MessagingTextBoxState();
@@ -102,7 +120,7 @@ class _MessagingTextBoxState extends State<MessagingTextBox>
     with WidgetsBindingObserver {
   double _bottomOffset = 50;
   late String? _recipientId;
-  late String? _conversationId;
+  late String _conversationId;
 
   final _textController = TextEditingController();
   bool _showRecordingIcon = false;
@@ -170,6 +188,7 @@ class _MessagingTextBoxState extends State<MessagingTextBox>
               message: _textController.text,
               messageType: textMessageFlag,
             ),
+            id: _conversationId,
           );
         } else {
           sendMessageCubit.sendGroupMessage(
@@ -180,7 +199,7 @@ class _MessagingTextBoxState extends State<MessagingTextBox>
               senderInfo: user,
               messageType: textMessageFlag,
             ),
-            id: _conversationId!,
+            id: _conversationId,
           );
         }
 

--- a/lib/app/features/chat/ui/views/widgets/recipient_chat_bubble.dart
+++ b/lib/app/features/chat/ui/views/widgets/recipient_chat_bubble.dart
@@ -8,7 +8,7 @@ class RecipientChatBubble extends StatelessWidget {
     super.key,
   });
 
-  final Message message;
+  final BaseMessage message;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/features/chat/ui/views/widgets/recipient_chat_bubble.dart
+++ b/lib/app/features/chat/ui/views/widgets/recipient_chat_bubble.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+import 'package:min_chat/app/features/chat/data/model/group_message.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 import 'package:min_chat/core/utils/datetime_x.dart';
 
@@ -36,9 +38,67 @@ class RecipientChatBubble extends StatelessWidget {
                     style: const TextStyle(color: Colors.black),
                     textWidthBasis: TextWidthBasis.longestLine,
                   ),
-
                   Padding(
-                   padding: const EdgeInsets.only(top: 8),
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Text(
+                      message.timestamp!.formatToTime,
+                      style: const TextStyle(fontSize: 11, color: Colors.grey),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class GroupRecipientChatBubble extends StatelessWidget {
+  const GroupRecipientChatBubble({
+    required this.message,
+    super.key,
+  });
+
+  final GroupMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: SizedBox(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 10),
+              decoration: const BoxDecoration(
+                color: Colors.black12,
+                borderRadius: BorderRadiusDirectional.only(
+                  topEnd: Radius.circular(8),
+                  bottomEnd: Radius.circular(8),
+                  bottomStart: Radius.circular(8),
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    message.senderInfo.name!,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: Colors.blueGrey,
+                    ),
+                  ),
+                  const Gap(5),
+                  Text(
+                    message.message,
+                    style: const TextStyle(color: Colors.black),
+                    textWidthBasis: TextWidthBasis.longestLine,
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
                     child: Text(
                       message.timestamp!.formatToTime,
                       style: const TextStyle(fontSize: 11, color: Colors.grey),

--- a/lib/app/features/chat/ui/views/widgets/recipient_voice_bubble.dart
+++ b/lib/app/features/chat/ui/views/widgets/recipient_voice_bubble.dart
@@ -2,6 +2,7 @@ import 'package:audio_video_progress_bar/audio_video_progress_bar.dart';
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
+import 'package:min_chat/app/features/chat/data/model/group_message.dart';
 import 'package:min_chat/app/features/chat/data/model/message.dart';
 import 'package:min_chat/app/features/chat/ui/views/widgets/message_button.dart';
 import 'package:min_chat/core/utils/datetime_x.dart';
@@ -13,7 +14,7 @@ class RecipientVoiceBubble extends StatefulWidget {
     super.key,
   });
 
-  final BaseMessage message;
+  final Message message;
 
   @override
   State<RecipientVoiceBubble> createState() => _RecipientVoiceBubbleState();
@@ -77,14 +78,6 @@ class _RecipientVoiceBubbleState extends State<RecipientVoiceBubble> {
         });
       }
     });
-
-    // _audioPlayer.onPlayerComplete.listen((_) {
-    //   if (mounted) {
-    //     // setState(() {
-    //       // _duration = Duration.zero;
-    //     // });
-    //   }
-    // });
   }
 
   @override
@@ -126,44 +119,190 @@ class _RecipientVoiceBubbleState extends State<RecipientVoiceBubble> {
               children: [
                 // if (message.status == sentStatusFlag ||
                 //     message.url != null) ...[
-                  CustomCircularIconButton(
-                    icon: _isPlaying ? Icons.pause : Icons.play_arrow,
-                    onPressed: _playPause,
-                  ),
-                  SizedBox(
-                    width: context.width * 0.3,
-                    child: ProgressBar(
-                      progress: _position,
-                      barHeight: 2,
-                      buffered: const Duration(milliseconds: 2000),
-                      total: _duration,
-                      progressBarColor: Colors.black,
-                      baseBarColor: Colors.white.withOpacity(0.24),
-                      bufferedBarColor: Colors.white.withOpacity(0.24),
-                      thumbColor: Colors.black,
-                      thumbRadius: 4,
-                      timeLabelType: TimeLabelType.totalTime,
-                      timeLabelLocation: TimeLabelLocation.none,
-                      timeLabelTextStyle: const TextStyle(
-                        color: Colors.grey,
-                      ),
-                      onSeek: _audioPlayer.seek,
+                CustomCircularIconButton(
+                  icon: _isPlaying ? Icons.pause : Icons.play_arrow,
+                  onPressed: _playPause,
+                ),
+                SizedBox(
+                  width: context.width * 0.3,
+                  child: ProgressBar(
+                    progress: _position,
+                    barHeight: 2,
+                    buffered: const Duration(milliseconds: 2000),
+                    total: _duration,
+                    progressBarColor: Colors.black,
+                    baseBarColor: Colors.white.withOpacity(0.24),
+                    bufferedBarColor: Colors.white.withOpacity(0.24),
+                    thumbColor: Colors.black,
+                    thumbRadius: 4,
+                    timeLabelType: TimeLabelType.totalTime,
+                    timeLabelLocation: TimeLabelLocation.none,
+                    timeLabelTextStyle: const TextStyle(
+                      color: Colors.grey,
                     ),
+                    onSeek: _audioPlayer.seek,
                   ),
-                // ],
+                ),
+               
+              ],
+            ),
+            const Gap(4),
+            Text(
+              message.timestamp!.formatToTime,
+              style: const TextStyle(fontSize: 11, color: Colors.grey),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
 
-                // else ...[
-                //   const CupertinoActivityIndicator(
-                //     color: Colors.grey,
-                //   ),
-                //   SizedBox(
-                //     width: context.width * 0.3,
-                //     child: const LinearProgressIndicator(
-                //       minHeight: 2,
-                //       color: Colors.grey,
-                //     ),
-                //   ),
-                // ],
+class GroupRecipientVoiceBubble extends StatefulWidget {
+  const GroupRecipientVoiceBubble({
+    required this.message,
+    super.key,
+  });
+
+  final GroupMessage message;
+
+  @override
+  State<GroupRecipientVoiceBubble> createState() =>
+      _GroupRecipientVoiceBubble();
+}
+
+class _GroupRecipientVoiceBubble extends State<GroupRecipientVoiceBubble> {
+  bool _isPlaying = false;
+  final AudioPlayer _audioPlayer = AudioPlayer();
+  Duration _duration = Duration.zero;
+  Duration _position = Duration.zero;
+
+  late GroupMessage message;
+
+  void _playPause() {
+    if (_isPlaying) {
+      _audioPlayer.pause();
+      setState(() {
+        _isPlaying = false;
+      });
+    } else {
+      _audioPlayer.play(UrlSource(message.url!));
+      setState(() {
+        _isPlaying = true;
+      });
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    message = widget.message;
+
+    // Add a listener to track changes in player state
+    _audioPlayer.onPlayerStateChanged.listen((PlayerState state) {
+      if (state == PlayerState.completed) {
+        // Audio has completed, reset the playback position to start
+        _audioPlayer.seek(Duration.zero);
+        if (mounted) {
+          setState(() {
+            _isPlaying = false;
+          });
+        }
+      }
+    });
+
+    // Listen for changes in audio duration
+    _audioPlayer.onDurationChanged.listen((Duration duration) {
+      if (mounted) {
+        setState(() {
+          _duration = duration;
+        });
+      }
+    });
+
+    // Listen for changes in audio position
+    _audioPlayer.onPositionChanged.listen((Duration position) {
+      if (mounted) {
+        setState(() {
+          _position = position;
+        });
+      }
+    });
+  }
+
+  @override
+  void didChangeDependencies() {
+    message = widget.message;
+    super.didChangeDependencies();
+  }
+
+  @override
+  void dispose() {
+    _audioPlayer.dispose();
+    super.dispose();
+  }
+
+  BoxDecoration get _recipientVoiceBoxDecoration => const BoxDecoration(
+        color: Colors.black12,
+        borderRadius: BorderRadiusDirectional.only(
+          topEnd: Radius.circular(8),
+          bottomEnd: Radius.circular(8),
+          bottomStart: Radius.circular(8),
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        width: 200,
+        height: 100,
+        padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 9),
+        decoration: _recipientVoiceBoxDecoration,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              message.senderInfo.name!,
+              style: const TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.blueGrey,
+              ),
+            ),
+            const Spacer(),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                // if (message.status == sentStatusFlag ||
+                //     message.url != null) ...[
+                CustomCircularIconButton(
+                  icon: _isPlaying ? Icons.pause : Icons.play_arrow,
+                  onPressed: _playPause,
+                ),
+                SizedBox(
+                  width: context.width * 0.3,
+                  child: ProgressBar(
+                    progress: _position,
+                    barHeight: 2,
+                    buffered: const Duration(milliseconds: 2000),
+                    total: _duration,
+                    progressBarColor: Colors.black,
+                    baseBarColor: Colors.white.withOpacity(0.24),
+                    bufferedBarColor: Colors.white.withOpacity(0.24),
+                    thumbColor: Colors.black,
+                    thumbRadius: 4,
+                    timeLabelType: TimeLabelType.totalTime,
+                    timeLabelLocation: TimeLabelLocation.none,
+                    timeLabelTextStyle: const TextStyle(
+                      color: Colors.grey,
+                    ),
+                    onSeek: _audioPlayer.seek,
+                  ),
+                ),
+              
               ],
             ),
             const Gap(4),

--- a/lib/app/features/chat/ui/views/widgets/recipient_voice_bubble.dart
+++ b/lib/app/features/chat/ui/views/widgets/recipient_voice_bubble.dart
@@ -13,7 +13,7 @@ class RecipientVoiceBubble extends StatefulWidget {
     super.key,
   });
 
-  final Message message;
+  final BaseMessage message;
 
   @override
   State<RecipientVoiceBubble> createState() => _RecipientVoiceBubbleState();
@@ -25,7 +25,7 @@ class _RecipientVoiceBubbleState extends State<RecipientVoiceBubble> {
   Duration _duration = Duration.zero;
   Duration _position = Duration.zero;
 
-  late Message message;
+  late BaseMessage message;
 
   void _playPause() {
     if (_isPlaying) {

--- a/lib/app/features/chat/ui/views/widgets/sender_chat_bubble.dart
+++ b/lib/app/features/chat/ui/views/widgets/sender_chat_bubble.dart
@@ -9,7 +9,7 @@ class SenderChatBubble extends StatelessWidget {
     super.key,
   });
 
-  final Message message;
+  final BaseMessage message;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/features/chat/ui/views/widgets/sender_voice_bubble.dart
+++ b/lib/app/features/chat/ui/views/widgets/sender_voice_bubble.dart
@@ -12,7 +12,7 @@ class SenderVoiceBubble extends StatefulWidget {
     required this.message,
     super.key,
   });
-  final Message message;
+  final BaseMessage message;
 
   @override
   State<SenderVoiceBubble> createState() => _SenderVoiceBubbleState();
@@ -24,7 +24,7 @@ class _SenderVoiceBubbleState extends State<SenderVoiceBubble> {
   Duration _duration = Duration.zero;
   Duration _position = Duration.zero;
 
-  late Message message;
+  late BaseMessage message;
 
   void _playPause() {
     if (_isPlaying) {

--- a/lib/app/features/chat/ui/views/widgets/voice_recorder_box.dart
+++ b/lib/app/features/chat/ui/views/widgets/voice_recorder_box.dart
@@ -16,8 +16,9 @@ import 'package:min_chat/core/utils/sized_context.dart';
 
 class VoiceRecorderBox extends StatefulWidget {
   const VoiceRecorderBox({
-     required this.audioPlayer, this.recipientId,
-     this.conversationId,
+    required this.audioPlayer,
+    this.recipientId,
+    this.conversationId,
     super.key,
   });
 
@@ -26,7 +27,7 @@ class VoiceRecorderBox extends StatefulWidget {
   final String? conversationId;
 
   /// AudioPlayer object is a required parameter here
-  /// so that the parent widget [TextVoiceBoxToggler] can
+  /// so that the parent widget TextVoiceBoxToggler can
   /// handle it's [AudioPlayer] disposal.
   final AudioPlayer audioPlayer;
 
@@ -281,6 +282,7 @@ class _RecorderControlsState extends State<_RecorderControls> {
       sendMessageCubit.sendVoiceMessage(
         message: message as Message,
         filePath: voiceCubit.path!,
+        id: widget.conversationId!,
       );
     } else {
       sendMessageCubit.sendGroupVoiceMessage(

--- a/lib/app/features/chat/ui/views/widgets/voice_recorder_box.dart
+++ b/lib/app/features/chat/ui/views/widgets/voice_recorder_box.dart
@@ -277,7 +277,7 @@ class _RecorderControlsState extends State<_RecorderControls> {
   }) {
     _playToneOnSendRecord();
 
-    if (isGroupChat) {
+    if (!isGroupChat) {
       sendMessageCubit.sendVoiceMessage(
         message: message as Message,
         filePath: voiceCubit.path!,

--- a/lib/app/shared/ui/app_button.dart
+++ b/lib/app/shared/ui/app_button.dart
@@ -5,7 +5,7 @@ class AppIconButton extends StatelessWidget {
   const AppIconButton({
     required this.text,
     required this.icon,
-    required this.onPressed,
+    this.onPressed,
     this.color,
     this.width,
     this.height,
@@ -21,7 +21,7 @@ class AppIconButton extends StatelessWidget {
   final double? borderRadius;
   final Widget icon;
   final bool isLoading;
-  final void Function() onPressed;
+  final void Function()? onPressed;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/shared/ui/app_button.dart
+++ b/lib/app/shared/ui/app_button.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
@@ -29,8 +30,8 @@ class AppIconButton extends StatelessWidget {
       onPressed: onPressed,
       icon: icon,
       label: isLoading
-          ? const CircularProgressIndicator.adaptive(
-              backgroundColor: Colors.white,
+          ? const CupertinoActivityIndicator(
+              color: Colors.white,
             )
           : Text(
               text,

--- a/lib/app/shared/ui/app_expandable_fab.dart
+++ b/lib/app/shared/ui/app_expandable_fab.dart
@@ -1,0 +1,216 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+@immutable
+class AppExpandableFab extends StatefulWidget {
+  const AppExpandableFab({
+    required this.distance,
+    required this.children,
+    super.key,
+    this.initialOpen,
+  });
+
+  final bool? initialOpen;
+  final double distance;
+  final List<Widget> children;
+
+  @override
+  State<AppExpandableFab> createState() => _AppExpandableFabState();
+}
+
+class _AppExpandableFabState extends State<AppExpandableFab>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _expandAnimation;
+  bool _open = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _open = widget.initialOpen ?? false;
+    _controller = AnimationController(
+      value: _open ? 1.0 : 0.0,
+      duration: const Duration(milliseconds: 250),
+      vsync: this,
+    );
+    _expandAnimation = CurvedAnimation(
+      curve: Curves.fastOutSlowIn,
+      reverseCurve: Curves.easeOutQuad,
+      parent: _controller,
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _toggle() {
+    setState(() {
+      _open = !_open;
+      if (_open) {
+        _controller.forward();
+      } else {
+        _controller.reverse();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.expand(
+      child: Stack(
+        alignment: Alignment.bottomRight,
+        clipBehavior: Clip.none,
+        children: [
+          _buildTapToCloseFab(),
+          ..._buildExpandingActionButtons(),
+          _buildTapToOpenFab(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTapToCloseFab() {
+    return SizedBox(
+      width: 56,
+      height: 56,
+      child: Center(
+        child: Material(
+          shape: const CircleBorder(),
+          clipBehavior: Clip.antiAlias,
+          elevation: 4,
+          child: InkWell(
+            onTap: _toggle,
+            child: const Padding(
+              padding: EdgeInsets.all(8),
+              child: Icon(
+                Icons.close,
+                color: Colors.black,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildExpandingActionButtons() {
+    final children = <Widget>[];
+    final count = widget.children.length;
+    final step = 90.0 / (count - 1);
+    for (var i = 0, angleInDegrees = 0.0;
+        i < count;
+        i++, angleInDegrees += step) {
+      children.add(
+        _ExpandingActionButton(
+          directionInDegrees: angleInDegrees,
+          maxDistance: widget.distance,
+          progress: _expandAnimation,
+          child: widget.children[i],
+        ),
+      );
+    }
+    return children;
+  }
+
+  Widget _buildTapToOpenFab() {
+    return IgnorePointer(
+      ignoring: _open,
+      child: AnimatedContainer(
+        transformAlignment: Alignment.center,
+        transform: Matrix4.diagonal3Values(
+          _open ? 0.7 : 1.0,
+          _open ? 0.7 : 1.0,
+          1,
+        ),
+        duration: const Duration(milliseconds: 250),
+        curve: const Interval(0, 0.5, curve: Curves.easeOut),
+        child: AnimatedOpacity(
+          opacity: _open ? 0.0 : 1.0,
+          curve: const Interval(0.25, 1, curve: Curves.easeInOut),
+          duration: const Duration(milliseconds: 250),
+          child: FloatingActionButton(
+            backgroundColor: Colors.black,
+            onPressed: _toggle,
+            child: const FaIcon(FontAwesomeIcons.userPlus),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+@immutable
+class _ExpandingActionButton extends StatelessWidget {
+  const _ExpandingActionButton({
+    required this.directionInDegrees,
+    required this.maxDistance,
+    required this.progress,
+    required this.child,
+  });
+
+  final double directionInDegrees;
+  final double maxDistance;
+  final Animation<double> progress;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: progress,
+      builder: (context, child) {
+        final offset = Offset.fromDirection(
+          directionInDegrees * (pi / 180.0),
+          progress.value * maxDistance,
+        );
+        return Positioned(
+          right: 4.0 + offset.dx,
+          bottom: 4.0 + offset.dy,
+          child: Transform.rotate(
+            angle: (1.0 - progress.value) * pi / 2,
+            child: child,
+          ),
+        );
+      },
+      child: FadeTransition(
+        opacity: progress,
+        child: child,
+      ),
+    );
+  }
+}
+
+@immutable
+class ActionButton extends StatelessWidget {
+  const ActionButton({
+    required this.icon,
+    this.tooltip,
+    super.key,
+    this.onPressed,
+  });
+
+  final VoidCallback? onPressed;
+  final Widget icon;
+  final String? tooltip;
+
+  @override
+  Widget build(BuildContext context) {
+    // final theme = Theme.of(context);
+    return Material(
+      shape: const CircleBorder(),
+      clipBehavior: Clip.antiAlias,
+      color: Colors.black,
+      elevation: 4,
+      child: IconButton(
+        tooltip: tooltip,
+        onPressed: onPressed,
+        icon: icon,
+        color: Colors.white,
+      ),
+    );
+  }
+}

--- a/lib/app/shared/ui/app_expandable_fab.dart
+++ b/lib/app/shared/ui/app_expandable_fab.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -62,14 +63,22 @@ class _AppExpandableFabState extends State<AppExpandableFab>
   @override
   Widget build(BuildContext context) {
     return SizedBox.expand(
-      child: Stack(
-        alignment: Alignment.bottomRight,
-        clipBehavior: Clip.none,
-        children: [
-          _buildTapToCloseFab(),
-          ..._buildExpandingActionButtons(),
-          _buildTapToOpenFab(),
-        ],
+      child: BackdropFilter(
+        filter: _open
+            ? ImageFilter.blur(
+                sigmaX: 2,
+                sigmaY: 2,
+              )
+            : ImageFilter.blur(),
+        child: Stack(
+          alignment: Alignment.bottomRight,
+          clipBehavior: Clip.none,
+          children: [
+            _buildTapToCloseFab(),
+            ..._buildExpandingActionButtons(),
+            _buildTapToOpenFab(),
+          ],
+        ),
       ),
     );
   }

--- a/lib/core/di/di.config.dart
+++ b/lib/core/di/di.config.dart
@@ -29,7 +29,9 @@ import 'package:min_chat/app/features/chat/data/chat_interface.dart' as _i12;
 import 'package:min_chat/app/features/chat/data/chat_repository.dart' as _i19;
 import 'package:min_chat/app/features/chat/data/firebase_chat_impl.dart'
     as _i13;
-import 'package:min_chat/core/di/module.dart' as _i20;
+import 'package:min_chat/app/features/chat/domain/get_conversations_use_case.dart'
+    as _i20;
+import 'package:min_chat/core/di/module.dart' as _i21;
 import 'package:min_chat/core/services/voice_recorder/record_voice_recorder.dart'
     as _i17;
 import 'package:min_chat/core/services/voice_recorder/voice_recorder.dart'
@@ -79,8 +81,10 @@ extension GetItInjectableX on _i1.GetIt {
       chatInterface: gh<_i12.IChat>(),
       userDao: gh<_i14.UserDao>(),
     ));
+    gh.singleton<_i20.GetConversationsUseCase>(_i20.GetConversationsUseCase(
+        chatRepository: gh<_i19.ChatRepository>()));
     return this;
   }
 }
 
-class _$RegisterModule extends _i20.RegisterModule {}
+class _$RegisterModule extends _i21.RegisterModule {}

--- a/lib/core/navigation/app_routes.dart
+++ b/lib/core/navigation/app_routes.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
-import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
 import 'package:min_chat/app/features/auth/ui/auth_screen.dart';
 import 'package:min_chat/app/features/auth/ui/cubit/authentication_cubit.dart';
+import 'package:min_chat/app/features/chat/data/model/conversation.dart';
 import 'package:min_chat/app/features/chat/data/model/group_conversation.dart';
 import 'package:min_chat/app/features/chat/ui/views/screens/chat_screen.dart';
 import 'package:min_chat/app/features/chat/ui/views/screens/group_chat_screen.dart';
@@ -44,9 +44,9 @@ class AppRoutes {
       path: Chats.name,
       name: 'chats',
       builder: (context, state) {
-        final minChatUser = state.extra! as MinChatUser;
+        final conversation = state.extra! as Conversation;
         return Chats(
-          recipientUser: minChatUser,
+          conversation: conversation,
         );
       },
     ),

--- a/lib/core/navigation/app_routes.dart
+++ b/lib/core/navigation/app_routes.dart
@@ -5,6 +5,7 @@ import 'package:min_chat/app/features/auth/ui/auth_screen.dart';
 import 'package:min_chat/app/features/auth/ui/cubit/authentication_cubit.dart';
 import 'package:min_chat/app/features/chat/ui/views/screens/chat_screen.dart';
 import 'package:min_chat/app/features/chat/ui/views/screens/messages_screen.dart';
+import 'package:min_chat/app/features/chat/ui/views/screens/start_groupchat_screen.dart';
 import 'package:min_chat/app/features/user/ui/user_options_screen.dart';
 
 class AppRoutes {
@@ -52,6 +53,12 @@ class AppRoutes {
       path: UserOptionsScreen.name,
       name: 'userOptions',
       builder: (context, state) => const UserOptionsScreen(),
+    ),
+
+    GoRoute(
+      path: StartGroupchatScreen.name,
+      name: 'startGroupchat',
+      builder: (context, state) => const StartGroupchatScreen(),
     ),
   ];
 }

--- a/lib/core/navigation/app_routes.dart
+++ b/lib/core/navigation/app_routes.dart
@@ -3,7 +3,9 @@ import 'package:go_router/go_router.dart';
 import 'package:min_chat/app/features/auth/data/model/authenticated_user.dart';
 import 'package:min_chat/app/features/auth/ui/auth_screen.dart';
 import 'package:min_chat/app/features/auth/ui/cubit/authentication_cubit.dart';
+import 'package:min_chat/app/features/chat/data/model/group_conversation.dart';
 import 'package:min_chat/app/features/chat/ui/views/screens/chat_screen.dart';
+import 'package:min_chat/app/features/chat/ui/views/screens/group_chat_screen.dart';
 import 'package:min_chat/app/features/chat/ui/views/screens/messages_screen.dart';
 import 'package:min_chat/app/features/chat/ui/views/screens/start_groupchat_screen.dart';
 import 'package:min_chat/app/features/user/ui/user_options_screen.dart';
@@ -45,6 +47,17 @@ class AppRoutes {
         final minChatUser = state.extra! as MinChatUser;
         return Chats(
           recipientUser: minChatUser,
+        );
+      },
+    ),
+
+    GoRoute(
+      path: GroupChatScreen.name,
+      name: 'groupChats',
+      builder: (context, state) {
+        final groupConversation = state.extra! as GroupConversation;
+        return GroupChatScreen(
+          groupConversation: groupConversation,
         );
       },
     ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -976,6 +976,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.11"
+  rxdart:
+    dependency: "direct main"
+    description:
+      name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.27.7"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   path_provider: ^2.1.1
   record: ^5.0.2
   redacted: ^1.0.11
+  rxdart: ^0.27.7
   shared_preferences: ^2.2.2
   toastification: 
 


### PR DESCRIPTION
Unfortunately, the need to create doc IDs for conversation documents on Firebase wasn't necessary.
Removing them would make all methods that require them run faster. The alternative is to let Firebase create the doc ID itself save it in the document itself and make use of it as needed. 

Creating the doc IDs manually, took about nlogn time (I think) because we sorted the chars' recipient id and sender id and concatenated it to form a doc ID.
